### PR TITLE
Allow adding new columns as NOT NULL

### DIFF
--- a/lib/nandi/instructions/add_column.rb
+++ b/lib/nandi/instructions/add_column.rb
@@ -3,7 +3,7 @@
 module Nandi
   module Instructions
     class AddColumn
-      attr_reader :table, :name, :type
+      attr_reader :table, :name, :type, :extra_args
 
       def initialize(table:, name:, type:, **kwargs)
         @table = table
@@ -14,10 +14,6 @@ module Nandi
 
       def procedure
         :add_column
-      end
-
-      def extra_args
-        { null: true, **@extra_args }
       end
 
       def lock

--- a/lib/nandi/validation/add_column_validator.rb
+++ b/lib/nandi/validation/add_column_validator.rb
@@ -13,7 +13,7 @@ module Nandi
 
       def call
         Result.new(@instruction).tap do |result|
-          result << "column isn't nullable" unless nullable?
+          result << "non-null column lacks default" unless nullable? || default_value?
           result << "column is unique" if unique?
         end
       end
@@ -21,6 +21,10 @@ module Nandi
       attr_reader :instruction
 
       private
+
+      def default_value?
+        !instruction.extra_args[:default].nil?
+      end
 
       def nullable?
         instruction.extra_args[:null]

--- a/spec/nandi/fixtures/rendered/active_record/create_and_drop_column.rb
+++ b/spec/nandi/fixtures/rendered/active_record/create_and_drop_column.rb
@@ -11,7 +11,6 @@ class MyAwesomeMigration < ActiveRecord::Migration[5.2]
   :foo,
   :text,
   {
-  null: true,
   collate: :de_DE
 }
 )

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -249,12 +249,6 @@ RSpec.describe Nandi::Migration do
       it "has the correct column type" do
         expect(instructions.first.type).to eq(:text)
       end
-
-      it "sets the default constraints" do
-        expect(instructions.first.extra_args).to eq(
-          null: true,
-        )
-      end
     end
 
     context "with extra options" do
@@ -286,7 +280,6 @@ RSpec.describe Nandi::Migration do
 
       it "sets the default constraints" do
         expect(instructions.first.extra_args).to eq(
-          null: true,
           collate: :de_DE,
         )
       end

--- a/spec/nandi/validator_spec.rb
+++ b/spec/nandi/validator_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "nandi/migration"
 require "nandi/validator"
+require "nandi/migration"
 require "nandi/instructions"
 
 RSpec.describe Nandi::Validator do
@@ -157,6 +158,22 @@ RSpec.describe Nandi::Validator do
       end
 
       it { is_expected.to_not be_valid }
+
+      context "and a default" do
+        let(:instructions) do
+          [
+            Nandi::Instructions::AddColumn.new(
+              table: :payments,
+              name: :stuff,
+              type: :text,
+              null: false,
+              default: "swilly!",
+            ),
+          ]
+        end
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context "with a default value" do


### PR DESCRIPTION
This was only unsafe because it required writing the default value to all existing rows pre-PG11. Now that's not true, we can not worry about NOT NULL for new columns. Adding the constraint to existing columns is still potentially hairy so that's still disallowed.