### PR TITLE
Add specific type methods to create_table

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ You'll get a fresh file, by default in `db/safe_migrations`. Let's use it to cre
 class AddWidgets < Nandi::Migration
   def up
     create_table :widgets do |t|
-      t.column :name, :text
-      t.column :price, :integer
+      t.text :name
+      t.integer :price
 
       t.timestamps
     end
@@ -255,7 +255,7 @@ Examples:
 
 ```rb
 create_table :widgets do |t|
-  t.column :foo, :text, default: true
+  t.text :foo, default: true
 end
 ```
 

--- a/lib/nandi/instructions/create_table.rb
+++ b/lib/nandi/instructions/create_table.rb
@@ -27,6 +27,38 @@ module Nandi
       class ColumnsReader
         attr_reader :columns, :timestamps_args
 
+        TYPES = %i[
+          bigint
+          binary
+          boolean
+          date
+          datetime
+          decimal
+          float
+          integer
+          json
+          string
+          text
+          time
+          timestamp
+          virtual
+          bigserial bit bit_varying box
+          cidr circle citext
+          daterange
+          hstore
+          inet int4range int8range interval
+          jsonb
+          line lseg ltree
+          macaddr money
+          numrange
+          oid
+          path point polygon primary_key
+          serial
+          tsrange tstzrange tsvector
+          uuid
+          xml
+        ].freeze
+
         def initialize
           @columns = []
           @timestamps_args = nil
@@ -38,6 +70,12 @@ module Nandi
 
         def timestamps(**args)
           @timestamps_args = args
+        end
+
+        TYPES.each do |type|
+          define_method type do |name, **args|
+            column(name, type, **args)
+          end
         end
       end
     end

--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -156,7 +156,7 @@ module Nandi
     # columns.
     # @example
     #   create_table :widgets do |t|
-    #     t.column :foo, :text, default: true
+    #     t.text :foo, default: true
     #   end
     # @param table [String, Symbol] The name of the new table
     # @yieldparam columns_reader [Nandi::Instructions::CreateTable::ColumnsReader]

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -249,6 +249,57 @@ RSpec.describe Nandi::Migration do
         expect(instructions.first.extra_args).to eq(id: false)
       end
     end
+
+    context "type methods" do
+      %i[
+        bigint
+        binary
+        boolean
+        date
+        datetime
+        decimal
+        float
+        integer
+        json
+        string
+        text
+        time
+        timestamp
+        virtual
+        bigserial bit bit_varying box
+        cidr circle citext
+        daterange
+        hstore
+        inet int4range int8range interval
+        jsonb
+        line lseg ltree
+        macaddr money
+        numrange
+        oid
+        path point polygon primary_key
+        serial
+        tsrange tstzrange tsvector
+        uuid
+        xml
+      ].each do |type|
+        context type.to_s do
+          let(:subject_class) do
+            Class.new(described_class) do
+              define_method :up do
+                create_table :payments do |t|
+                  t.send type, :name, null: true
+                end
+              end
+            end
+          end
+
+          it "defines the type #{type}" do
+            expect(instructions.first.columns.first.type).
+              to eq(type)
+          end
+        end
+      end
+    end
   end
 
   describe "#drop_table" do


### PR DESCRIPTION
WHY?

Scratching an itch ... 

Allows
```rb
create_table :t do |t|
  t.text :foo, default: "ZALGO"
end
```