### PR TITLE
Allow requiring a file in enforcer

### DIFF
--- a/exe/nandi-enforce
+++ b/exe/nandi-enforce
@@ -18,6 +18,9 @@ OptionParser.new do |o|
   o.on("--ar-migration-dir DIR", "directory containing ActiveRecord migrations") do |v|
     opts[:ar_migration_dir] = v
   end
+  o.on("--require PATH", "file to require before execution") do |v|
+    opts[:require_path] = v
+  end
   o.on("-h", "--help") do
     puts o
     exit

--- a/lib/nandi/safe_migration_enforcer.rb
+++ b/lib/nandi/safe_migration_enforcer.rb
@@ -11,10 +11,13 @@ module Nandi
     DEFAULT_SAFE_MIGRATION_DIR = "db/safe_migrations"
     DEFAULT_AR_MIGRATION_DIR = "db/migrate"
 
-    def initialize(safe_migration_dir: DEFAULT_SAFE_MIGRATION_DIR,
+    def initialize(require_path: nil,
+                   safe_migration_dir: DEFAULT_SAFE_MIGRATION_DIR,
                    ar_migration_dir: DEFAULT_AR_MIGRATION_DIR)
       @safe_migration_dir = safe_migration_dir
       @ar_migration_dir = ar_migration_dir
+
+      require require_path unless require_path.nil?
 
       Nandi.configure do |c|
         c.migration_directory = @safe_migration_dir


### PR DESCRIPTION
Adding this option will allow us to use the configuration of the host app when checking enforcement; this will allow us to fix the issue raised by @stephenbinns 