### PR TITLE
Removes trailing blank lines from template files

### DIFF
--- a/lib/generators/nandi/foreign_key/templates/add_foreign_key.rb
+++ b/lib/generators/nandi/foreign_key/templates/add_foreign_key.rb
@@ -11,4 +11,3 @@ class <%= add_foreign_key_name.camelize %> < Nandi::Migration
     drop_constraint <%= format_value(table) %>, <%= format_value(name) %>
   end
 end
-

--- a/lib/generators/nandi/foreign_key/templates/validate_foreign_key.rb
+++ b/lib/generators/nandi/foreign_key/templates/validate_foreign_key.rb
@@ -7,4 +7,3 @@ class <%= validate_foreign_key_name.camelize %> < Nandi::Migration
 
   def down; end
 end
-

--- a/lib/generators/nandi/migration/templates/migration.rb
+++ b/lib/generators/nandi/migration/templates/migration.rb
@@ -11,4 +11,3 @@ class <%= class_name %> < Nandi::Migration
     # remove_index :payments, :index_payments_on_foo_bar
   end
 end
-

--- a/lib/generators/nandi/not_null_check/templates/add_not_null_check.rb
+++ b/lib/generators/nandi/not_null_check/templates/add_not_null_check.rb
@@ -9,4 +9,3 @@ class <%= add_not_null_check_name.camelize %> < Nandi::Migration
     drop_constraint <%= format_value(table) %>, <%= format_value(name) %>
   end
 end
-

--- a/lib/generators/nandi/not_null_check/templates/validate_not_null_check.rb
+++ b/lib/generators/nandi/not_null_check/templates/validate_not_null_check.rb
@@ -7,4 +7,3 @@ class <%= validate_not_null_check_name.camelize %> < Nandi::Migration
 
   def down; end
 end
-


### PR DESCRIPTION
I'm not sure if there is a reason to have blank lines at the end of template files (maybe this is a Rails requirement), but I decided to give it a go a remove them. Let me know if this makes sense.

Main motivation behind this is the Rubocop Layout/TrailingBlankLines cop. With this change files generated by Nandi should have no Rubocop offences.