### PR TITLE
Do not recompile all migrations by default

### DIFF
--- a/lib/generators/nandi/compile/compile_generator.rb
+++ b/lib/generators/nandi/compile/compile_generator.rb
@@ -8,8 +8,17 @@ module Nandi
   class CompileGenerator < Rails::Generators::Base
     source_root File.expand_path("templates", __dir__)
 
+    class_option :files,
+                 type: :string,
+                 default: "git-diff",
+                 desc: <<-DESC
+                 Files to compile. May be a glob pattern or one of the following:
+                 -- 'all' compiles all files
+                 -- 'git-diff' only changed.
+                 DESC
+
     def compile_migration_files
-      Nandi.compile(files: Dir.glob(safe_migrations_glob)) do |results|
+      Nandi.compile(files: files) do |results|
         results.each do |result|
           create_file "#{output_path}/#{result.file_name}", result.body, force: true
         end
@@ -26,8 +35,30 @@ module Nandi
       end
     end
 
+    def compiled_migrations_glob
+      File.expand_path("*.rb", output_path)
+    end
+
     def output_path
       Nandi.config.output_directory || "db/migrate"
+    end
+
+    def files
+      safe_migrations = Dir.glob(safe_migrations_glob)
+      case options["files"]
+      when "all"
+        safe_migrations
+      when "git-diff"
+        changed_files & safe_migrations
+      else
+        Dir.glob(options["files"])
+      end
+    end
+
+    def changed_files
+      `git status -s`.lines.map do |line|
+        Rails.root.join(line.chomp.strip.split[1]).to_s
+      end
     end
   end
 end


### PR DESCRIPTION
A first pass at https://gocardless.atlassian.net/browse/DE-160.

It unsurprisingly speeds things up dramatically. However, it won't recompile migrations after changes. So we probably need to think about how we deal with that.

Option 1: add another class option, `--files`, that will allow people to pass in a glob pattern to compile. PROS: works 'out of the box'. CONS: suboptimal UX.

Option 2: Use a Git library to add dirty files in the output directory to the eventual glob. Pros: transparent once setup. Cons: we can't assume people are using Git in good conscience and it would be a weird dependency to take on

Options 3-_n_: over to you!  