### PR TITLE
Adds migration method: irreversible_migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ Because we cannot run in a transaction and therefore risk partially applied migr
 ### `#drop_table(table)`
 Drops an existing table.
 
+### `#irreversible_migration`
+Raises `ActiveRecord::IrreversibleMigration` error.
+
 ## Configuration
 
 Nandi can be configured in various ways, typically in an initializer:

--- a/lib/nandi/instructions.rb
+++ b/lib/nandi/instructions.rb
@@ -12,6 +12,7 @@ require "nandi/instructions/drop_constraint"
 require "nandi/instructions/remove_not_null_constraint"
 require "nandi/instructions/validate_constraint"
 require "nandi/instructions/add_check_constraint"
+require "nandi/instructions/irreversible_migration"
 
 module Nandi
   module Instructions; end

--- a/lib/nandi/instructions/irreversible_migration.rb
+++ b/lib/nandi/instructions/irreversible_migration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Nandi
+  module Instructions
+    class IrreversibleMigration
+      def procedure
+        :irreversible_migration
+      end
+    end
+  end
+end

--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -286,6 +286,12 @@ module Nandi
       )
     end
 
+    # Raises an `ActiveRecord::IrreversibleMigration` error for use in
+    # irreversible migrations
+    def irreversible_migration
+      current_instructions << Instructions::IrreversibleMigration.new
+    end
+
     # @api private
     def compile_instructions(direction)
       @direction = direction

--- a/lib/nandi/renderers/active_record/instructions.rb
+++ b/lib/nandi/renderers/active_record/instructions.rb
@@ -126,6 +126,8 @@ module Nandi
           property :table
           property :name
         end
+
+        class IrreversibleMigrationCell < Base; end
       end
     end
   end

--- a/lib/templates/nandi/renderers/active_record/instructions/irreversible_migration/show.rb.erb
+++ b/lib/templates/nandi/renderers/active_record/instructions/irreversible_migration/show.rb.erb
@@ -1,0 +1,1 @@
+raise ActiveRecord::IrreversibleMigration

--- a/spec/nandi/fixtures/rendered/active_record/irreversible_migration.rb
+++ b/spec/nandi/fixtures/rendered/active_record/irreversible_migration.rb
@@ -1,0 +1,24 @@
+class MyAwesomeMigration < ActiveRecord::Migration[5.2]
+  
+  set_lock_timeout(750)
+  set_statement_timeout(1500)
+
+  
+  def up
+  
+    remove_column(
+  :payments,
+  :amount,
+  nil
+)
+
+  
+  end
+  
+  def down
+  
+    raise ActiveRecord::IrreversibleMigration
+  
+  end
+  
+end

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -686,6 +686,26 @@ RSpec.describe Nandi::Migration do
     end
   end
 
+  describe "#irreversible_migration" do
+    subject(:instructions) { subject_class.new(validator).down_instructions }
+
+    let(:subject_class) do
+      Class.new(described_class) do
+        def up
+          remove_column :payments, :amount
+        end
+
+        def down
+          irreversible_migration
+        end
+      end
+    end
+
+    it "has the correct procedure" do
+      expect(instructions.first.procedure).to eq(:irreversible_migration)
+    end
+  end
+
   describe "syntax extensions" do
     subject(:instructions) { subject_class.new(validator).up_instructions }
 

--- a/spec/nandi/renderers/active_record_spec.rb
+++ b/spec/nandi/renderers/active_record_spec.rb
@@ -344,6 +344,30 @@ RSpec.describe Nandi::Renderers::ActiveRecord do
       it { is_expected.to eq(fixture) }
     end
 
+    describe "#irreversible_migration" do
+      let(:fixture) do
+        File.read(File.join(fixture_root, "irreversible_migration.rb"))
+      end
+
+      let(:safe_migration) do
+        Class.new(Nandi::Migration) do
+          def self.name
+            "MyAwesomeMigration"
+          end
+
+          def up
+            remove_column :payments, :amount
+          end
+
+          def down
+            irreversible_migration
+          end
+        end
+      end
+
+      it { is_expected.to eq(fixture) }
+    end
+
     describe "custom instructions" do
       let(:fixture) do
         File.read(File.join(fixture_root, "custom_instruction.rb"))


### PR DESCRIPTION
[Ticket](https://gocardless.atlassian.net/browse/DE-30)

Raises an `ActiveRecord::IrreversibleMigration` error for use in irreversible migrations.

Dear Reviewer, i need your inputs on:

1. AFAICS, we've not done this for other migration methods, so do we need a validation to avoid use of `irreversible_migration` in the `up` method? don't think it'll be straight-forward to do that because the current validations don't seem to be aware of where instructions are being called from.

2. Does anything else need to be updated in order to call this complete? (this is my first nandi PR, so).