### PR TITLE
Use :validate for generating foreign keys

### DIFF
--- a/lib/nandi/instructions/add_foreign_key.rb
+++ b/lib/nandi/instructions/add_foreign_key.rb
@@ -22,7 +22,7 @@ module Nandi
         {
           **@extra_args,
           name: name,
-          valid: false,
+          validate: false,
         }.compact
       end
 

--- a/spec/nandi/fixtures/rendered/active_record/add_foreign_key.rb
+++ b/spec/nandi/fixtures/rendered/active_record/add_foreign_key.rb
@@ -12,7 +12,7 @@ class MyAwesomeMigration < ActiveRecord::Migration[5.2]
   {
   column: :zalgo_comes,
   name: :payments_mandates_fk,
-  valid: false
+  validate: false
 }
 )
 

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe Nandi::Migration do
 
       it "has the correct extra args" do
         expect(instructions.first.extra_args).to eq(
-          valid: false,
+          validate: false,
           name: :payments_mandates_fk,
         )
       end
@@ -506,7 +506,7 @@ RSpec.describe Nandi::Migration do
       it "has the correct extra args" do
         expect(instructions.first.extra_args).to eq(
           name: :zalgo_comes,
-          valid: false,
+          validate: false,
         )
       end
     end
@@ -538,7 +538,7 @@ RSpec.describe Nandi::Migration do
         expect(instructions.first.extra_args).to eq(
           column: :zalgo_comes,
           name: :payments_mandates_fk,
-          valid: false,
+          validate: false,
         )
       end
     end


### PR DESCRIPTION
:valid is not an accepted option. Annoyingly Rails doesn't tell you this and will foolishly accept an unused argument. I found this locally by chance because my big migration broke in Draupnir and I noticed the emitted SQL didn't include `NOT VALID`.

https://apidock.com/rails/v5.2.3/ActiveRecord/ConnectionAdapters/SchemaStatements/add_foreign_key