### PR TITLE
Allow longer timeouts on validate_constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nandi (0.4.0)
+    nandi (0.4.2)
       activesupport
       cells
       tilt

--- a/lib/nandi/instructions/validate_constraint.rb
+++ b/lib/nandi/instructions/validate_constraint.rb
@@ -10,6 +10,10 @@ module Nandi
         @name = name
       end
 
+      def lock
+        Nandi::Migration::LockWeights::SHARE
+      end
+
       def procedure
         :validate_constraint
       end

--- a/nandi.gemspec
+++ b/nandi.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "nandi"
-  spec.version       = "0.4.1"
+  spec.version       = "0.4.2"
   spec.authors       = ["James Turley"]
   spec.email         = ["jamesturley@gocardless.com"]
 

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -624,6 +624,12 @@ RSpec.describe Nandi::Migration do
     it "has the correct constraint name" do
       expect(instructions.first.name).to eq(:payments_mandates_fk)
     end
+
+    it "has a low lock weight" do
+      expect(instructions.first.lock).to eq(
+        described_class::LockWeights::SHARE,
+      )
+    end
   end
 
   describe "#remove_not_null_constraint" do


### PR DESCRIPTION
`ALTER TABLE VALIDATE CONSTRAINT` only takes a `ShareUpdateExclusive` lock meaning it does not conflict with reads or writes, so we don't need to worry about availability here. This will allow higher timeouts as requested by @nickcampbell18 