### PR TITLE
Class option for validation timeout in constraint generators

### DIFF
--- a/lib/generators/nandi/check_constraint/USAGE
+++ b/lib/generators/nandi/check_constraint/USAGE
@@ -9,3 +9,11 @@ Example:
         db/safe_migrations/20190424123727_add_check_constraint_baz_or_quux_not_null_on_foos.rb
         db/safe_migrations/20190424123728_validate_check_constraint_baz_or_quux_not_null_on_foos.rb
 
+Example:
+    rails generate nandi:check_constraint foos baz_or_quux_not_null --validation-timeout 20000
+
+    This will create:
+        db/safe_migrations/20190424123727_add_check_constraint_baz_or_quux_not_null_on_foos.rb
+        db/safe_migrations/20190424123728_validate_check_constraint_baz_or_quux_not_null_on_foos.rb
+
+    The statement timeout in the second migration will be set to 20,000ms.

--- a/lib/generators/nandi/check_constraint/check_constraint_generator.rb
+++ b/lib/generators/nandi/check_constraint/check_constraint_generator.rb
@@ -9,6 +9,7 @@ module Nandi
 
     argument :table, type: :string
     argument :name, type: :string
+    class_option :validation_timeout, type: :numeric, default: 15 * 60 * 1000
 
     source_root File.expand_path("templates", __dir__)
 
@@ -46,6 +47,10 @@ module Nandi
 
     def timestamp(offset = 0)
       (Time.now.utc + offset).strftime("%Y%m%d%H%M%S")
+    end
+
+    def validation_timeout
+      options["validation_timeout"]
     end
   end
 end

--- a/lib/generators/nandi/check_constraint/templates/validate_check_constraint.rb
+++ b/lib/generators/nandi/check_constraint/templates/validate_check_constraint.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class <%= validate_check_constraint_name.camelize %> < Nandi::Migration
+  set_statement_timeout(<%= format_value(validation_timeout) %>)
+
   def up
     validate_constraint <%= format_value(table) %>, <%= format_value(name) %>
   end

--- a/lib/generators/nandi/foreign_key/USAGE
+++ b/lib/generators/nandi/foreign_key/USAGE
@@ -13,6 +13,17 @@ Example:
     Will create an FK constraint called foos_bars_fk
 
 Example:
+    rails generate nandi:foreign_key foos bars --validation-timeout 20000
+
+    This will create:
+        db/safe_migrations/20190424123727_add_foreign_key_on_bars_to_foos.rb
+        db/safe_migrations/20190424123728_validate_foreign_key_on_bars_to_foos.rb
+
+    Assumes that there is a column on table foos called bar_id that points to bars.
+    Will create an FK constraint called foos_bars_fk. Will set the statement timeout
+    on the second migration to 20,000ms
+
+Example:
     rails generate nandi:foreign_key foos bars --column special_bar_id --name my_fk
 
     This will create:

--- a/lib/generators/nandi/foreign_key/foreign_key_generator.rb
+++ b/lib/generators/nandi/foreign_key/foreign_key_generator.rb
@@ -11,6 +11,7 @@ module Nandi
     argument :target, type: :string
     class_option :name, type: :string
     class_option :column, type: :string
+    class_option :validation_timeout, type: :numeric, default: 15 * 60 * 1000
 
     source_root File.expand_path("templates", __dir__)
 
@@ -60,6 +61,10 @@ module Nandi
 
     def any_options?
       options["name"] || options["column"]
+    end
+
+    def validation_timeout
+      options["validation_timeout"]
     end
   end
 end

--- a/lib/generators/nandi/foreign_key/templates/validate_foreign_key.rb
+++ b/lib/generators/nandi/foreign_key/templates/validate_foreign_key.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class <%= validate_foreign_key_name.camelize %> < Nandi::Migration
+  set_statement_timeout(<%= format_value(validation_timeout) %>)
+
   def up
     validate_constraint <%= format_value(@table) %>, <%= format_value(name) %>
   end

--- a/lib/generators/nandi/not_null_check/USAGE
+++ b/lib/generators/nandi/not_null_check/USAGE
@@ -8,3 +8,12 @@ Example:
     This will create:
         db/safe_migrations/20190424123727_add_not_null_check_on_bar_to_foos.rb
         db/safe_migrations/20190424123728_validate_not_null_check_on_bar_to_foos.rb
+
+Example:
+    rails generate nandi:not_null_check foos bar --validation-timeout 20000
+
+    This will create:
+        db/safe_migrations/20190424123727_add_not_null_check_on_bar_to_foos.rb
+        db/safe_migrations/20190424123728_validate_not_null_check_on_bar_to_foos.rb
+
+    The statement timeout in the second migration will be set to 20,000ms.

--- a/lib/generators/nandi/not_null_check/not_null_check_generator.rb
+++ b/lib/generators/nandi/not_null_check/not_null_check_generator.rb
@@ -9,6 +9,7 @@ module Nandi
 
     argument :table, type: :string
     argument :column, type: :string
+    class_option :validation_timeout, type: :numeric, default: 15 * 60 * 1000
 
     source_root File.expand_path("templates", __dir__)
 
@@ -50,6 +51,10 @@ module Nandi
 
     def name
       "#{table}_check_#{column}_not_null"
+    end
+
+    def validation_timeout
+      options["validation_timeout"]
     end
   end
 end

--- a/lib/generators/nandi/not_null_check/templates/validate_not_null_check.rb
+++ b/lib/generators/nandi/not_null_check/templates/validate_not_null_check.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class <%= validate_not_null_check_name.camelize %> < Nandi::Migration
+  set_statement_timeout(<%= format_value(validation_timeout) %>)
+
   def up
     validate_constraint <%= format_value(@table) %>, <%= format_value(name) %>
   end


### PR DESCRIPTION
Also set the default to something much higher (15 minutes).