### PR TITLE
Fix irreversible_migration feature

### DIFF
--- a/lib/nandi/validator.rb
+++ b/lib/nandi/validator.rb
@@ -58,9 +58,13 @@ module Nandi
     end
 
     def at_most_one_object_modified
-      [migration.up_instructions, migration.down_instructions].map do |instructions|
-        instructions.map(&:table).map(&:to_sym).uniq.count <= 1
-      end.all?
+      [migration.up_instructions, migration.down_instructions].all? do |instructions|
+        affected_tables = instructions.map do |instruction|
+          instruction.respond_to?(:table) && instruction.table.to_sym
+        end
+
+        affected_tables.uniq.count <= 1
+      end
     end
 
     def new_indexes_are_separated_from_other_migrations

--- a/spec/nandi/validator_spec.rb
+++ b/spec/nandi/validator_spec.rb
@@ -95,6 +95,12 @@ RSpec.describe Nandi::Validator do
     end
   end
 
+  context "with an irreversible migration" do
+    let(:instructions) { [Nandi::Instructions::IrreversibleMigration.new] }
+
+    it { is_expected.to be_valid }
+  end
+
   context "with more than one object modified" do
     let(:instructions) do
       [


### PR DESCRIPTION
> Ticket: https://gocardless.atlassian.net/browse/DE-222

We could inject a fake table into this function but instead, like the `#lock` function being optional, we can just check if `#table` is defined (logically, not all operations occur on a table anyway so this should be future-proof).