### PR TITLE
Do not restrict timeouts on IrreversibleMigration

### DIFF
--- a/lib/nandi/instructions/irreversible_migration.rb
+++ b/lib/nandi/instructions/irreversible_migration.rb
@@ -3,6 +3,10 @@
 module Nandi
   module Instructions
     class IrreversibleMigration
+      def lock
+        Nandi::Migration::LockWeights::SHARE
+      end
+
       def procedure
         :irreversible_migration
       end

--- a/nandi.gemspec
+++ b/nandi.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "nandi"
-  spec.version       = "0.4.2"
+  spec.version       = "0.4.3"
   spec.authors       = ["James Turley"]
   spec.email         = ["jamesturley@gocardless.com"]
 

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -706,6 +706,12 @@ RSpec.describe Nandi::Migration do
     it "has the correct procedure" do
       expect(instructions.first.procedure).to eq(:irreversible_migration)
     end
+
+    it "has a low lock weight" do
+      expect(instructions.first.lock).to eq(
+        described_class::LockWeights::SHARE,
+      )
+    end
   end
 
   describe "syntax extensions" do


### PR DESCRIPTION
This instruction doesn't actually execute any SQL at all, so should not restrict lock/statement timeouts. 