### PR TITLE
Support tables with numeric names

### DIFF
--- a/lib/nandi.rb
+++ b/lib/nandi.rb
@@ -47,7 +47,7 @@ module Nandi
     def compiled_migration(file_path)
       require file_path
 
-      file_name, class_name = /\d+_([a-z_]+)\.rb\z/.match(file_path)[0..1]
+      file_name, class_name = /\d+_([a-z0-9_]+)\.rb\z/.match(file_path)[0..1]
 
       migration = class_name.camelize.constantize.new(validator)
 


### PR DESCRIPTION
We should be able to process things like CreateIr2019049Batches
migration names, but the existing code would think the migration is
referencing a class called 'Batches'. This extends the regex to respect
numbers too.