### PR TITLE
Remove implicit dependency on the facets gem

### DIFF
--- a/lib/generators/nandi/migration/migration_generator.rb
+++ b/lib/generators/nandi/migration/migration_generator.rb
@@ -11,7 +11,7 @@ module Nandi
 
       template(
         "migration.rb",
-        "#{base_path}/#{timestamp}_#{file_name.snakecase}.rb",
+        "#{base_path}/#{timestamp}_#{snakecase(file_name)}.rb",
       )
     end
 
@@ -19,6 +19,15 @@ module Nandi
 
     def base_path
       Nandi.config.migration_directory || "db/safe_migrations"
+    end
+
+    def snakecase(str)
+      str.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
+        gsub(/([a-z\d])([A-Z])/, '\1_\2').
+        tr("-", "_").
+        gsub(/\s/, "_").
+        gsub(/__+/, "_").
+        downcase
     end
   end
 end


### PR DESCRIPTION
The `snakecase` method is not part of Rails or ActiveRecord but is
included in the "facets" gem, which however is not explicitely required
by nandi (though it's used indirectly by many other projects at GC).

This commit removes that implicit dependency by just porting the same
implementation of the `snakecase` method, allowing projects that do not
include that dependency to also use nandi.

We noticed this when I tried to include nandi in nexus (where we use rails, but do not have anything else that requires facets) and was welcomed with the following error:
![image](https://user-images.githubusercontent.com/25649/66933763-6defb300-f031-11e9-9c4a-eebeb18d36ae.png)

I'm not sure how to tests this change (do you have any ideas?) but It Works On My Machine™️ now