### PR TITLE
Use snake-case converter from ActiveSupport::Inflector

### DIFF
--- a/lib/generators/nandi/migration/migration_generator.rb
+++ b/lib/generators/nandi/migration/migration_generator.rb
@@ -11,7 +11,7 @@ module Nandi
 
       template(
         "migration.rb",
-        "#{base_path}/#{timestamp}_#{file_name.snakecase}.rb",
+        "#{base_path}/#{timestamp}_#{file_name.underscore}.rb",
       )
     end
 

--- a/nandi.gemspec
+++ b/nandi.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "nandi"
-  spec.version       = "0.4.3"
+  spec.version       = "0.4.4"
   spec.authors       = ["James Turley"]
   spec.email         = ["jamesturley@gocardless.com"]
 


### PR DESCRIPTION
I thought the snakecase method was coming from ActiveSupport but it's
coming from some other string monkeypatch library that's autoloaded in
payments-service. This meant than Nandi didn't work when added to Nexus
which does not have that dependency. This should guarantee the generator
will work in any Rails app.