### PR TITLE
Refactor validations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,3 +50,5 @@ Naming/UncommunicativeMethodParamName:
     - x
     - y
     - of
+    # Useful as a placeholder for an unused argument
+    - _

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     nandi (0.5.0)
       activesupport
       cells
+      dry-monads
       tilt
 
 GEM
@@ -66,6 +67,13 @@ GEM
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
     diff-lcs (1.3)
+    dry-core (0.4.9)
+      concurrent-ruby (~> 1.0)
+    dry-equalizer (0.2.2)
+    dry-monads (1.3.1)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.4, >= 0.4.4)
+      dry-equalizer
     erubi (1.8.0)
     gc_ruboconfig (2.3.14)
       rubocop (>= 0.57, < 0.62)

--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -2,6 +2,7 @@
 
 require "nandi/instructions"
 require "nandi/validator"
+require "nandi/validation/failure_helpers"
 
 module Nandi
   # @abstract A migration must implement #up (the forward migration), and may
@@ -25,6 +26,8 @@ module Nandi
   #       end
   #     end
   class Migration
+    include Nandi::Validation::FailureHelpers
+
     module LockWeights
       ACCESS_EXCLUSIVE = 1
       SHARE = 0
@@ -293,7 +296,7 @@ module Nandi
     def validate
       validator.call(self)
     rescue NotImplementedError => e
-      Validation::Result.new << e.message
+      Validation::Result.new << failure(e.message)
     end
 
     def name

--- a/lib/nandi/timeout_policies.rb
+++ b/lib/nandi/timeout_policies.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+require "nandi/migration"
+require "nandi/timeout_policies/access_exclusive"
+
+module Nandi
+  module TimeoutPolicies
+    class Noop
+      class << self
+        include Dry::Monads[:result]
+
+        def validate(_)
+          Success()
+        end
+      end
+    end
+
+    def self.policy_for(instruction)
+      case instruction.lock
+      when Nandi::Migration::LockWeights::ACCESS_EXCLUSIVE
+        AccessExclusive
+      else
+        Noop
+      end
+    end
+  end
+end

--- a/lib/nandi/timeout_policies/access_exclusive.rb
+++ b/lib/nandi/timeout_policies/access_exclusive.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "nandi"
+require "nandi/validation/failure_helpers"
+
+module Nandi
+  module TimeoutPolicies
+    class AccessExclusive
+      include Nandi::Validation::FailureHelpers
+
+      def self.validate(migration)
+        new(migration).validate
+      end
+
+      def initialize(migration)
+        @migration = migration
+      end
+
+      def validate
+        collect_errors(validate_statement_timeout, validate_lock_timeout)
+      end
+
+      private
+
+      attr_reader :migration
+
+      def validate_statement_timeout
+        assert(
+          migration.statement_timeout <= statement_timeout_maximum,
+          "statement timeout must be at most #{statement_timeout_maximum}ms" \
+          " as it takes an ACCESS EXCLUSIVE lock",
+        )
+      end
+
+      def validate_lock_timeout
+        assert(
+          migration.lock_timeout <= lock_timeout_maximum,
+          "lock timeout must be at most #{lock_timeout_maximum}ms" \
+          " as it takes an ACCESS EXCLUSIVE lock",
+        )
+      end
+
+      def statement_timeout_maximum
+        Nandi.config.access_exclusive_statement_timeout_limit
+      end
+
+      def lock_timeout_maximum
+        Nandi.config.access_exclusive_lock_timeout_limit
+      end
+    end
+  end
+end

--- a/lib/nandi/validation.rb
+++ b/lib/nandi/validation.rb
@@ -4,5 +4,7 @@ require "nandi/validation/add_column_validator"
 require "nandi/validation/remove_index_validator"
 require "nandi/validation/each_validator"
 require "nandi/validation/result"
+require "nandi/validation/failure_helpers"
+require "nandi/validation/timeout_validator"
 
 module Validation; end

--- a/lib/nandi/validation/add_column_validator.rb
+++ b/lib/nandi/validation/add_column_validator.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "nandi/validation/failure_helpers"
+
 module Nandi
   module Validation
     class AddColumnValidator
+      include Nandi::Validation::FailureHelpers
+
       def self.call(instruction)
         new(instruction).call
       end
@@ -12,10 +16,11 @@ module Nandi
       end
 
       def call
-        Result.new(@instruction).tap do |result|
-          result << "non-null column lacks default" unless nullable? || default_value?
-          result << "column is unique" if unique?
-        end
+        collect_errors(
+          assert(nullable? || default_value?,
+                 "add_column: non-null column lacks default"),
+          assert(!unique?, "add_column: column is unique"),
+        )
       end
 
       attr_reader :instruction

--- a/lib/nandi/validation/each_validator.rb
+++ b/lib/nandi/validation/each_validator.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "nandi/validation/failure_helpers"
+
 module Nandi
   module Validation
     class EachValidator
+      include Nandi::Validation::FailureHelpers
+
       def self.call(instruction)
         new(instruction).call
       end
@@ -12,14 +16,14 @@ module Nandi
       end
 
       def call
-        result = Result.new
         case instruction.procedure
         when :remove_index
-          result.merge(RemoveIndexValidator.call(instruction))
+          RemoveIndexValidator.call(instruction)
         when :add_column
-          result.merge(AddColumnValidator.call(instruction))
+          AddColumnValidator.call(instruction)
+        else
+          success
         end
-        result
       end
 
       attr_reader :instruction

--- a/lib/nandi/validation/failure_helpers.rb
+++ b/lib/nandi/validation/failure_helpers.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "dry/monads/result"
+
+module Nandi
+  module Validation
+    module FailureHelpers
+      def collect_errors(new, old)
+        return success if new.success? && old.success?
+
+        if old.failure?
+          failure(Array(old.failure) + Array(new.failure))
+        else
+          failure(Array(new.failure))
+        end
+      end
+
+      def success
+        Dry::Monads::Result::Success.new(nil)
+      end
+
+      def failure(value)
+        Dry::Monads::Result::Failure.new(value)
+      end
+
+      def assert(condition, message)
+        if condition
+          success
+        else
+          failure(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/nandi/validation/remove_index_validator.rb
+++ b/lib/nandi/validation/remove_index_validator.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "nandi/validation/failure_helpers"
+
 module Nandi
   module Validation
     class RemoveIndexValidator
+      include Nandi::Validation::FailureHelpers
+
       def self.call(instruction)
         new(instruction).call
       end
@@ -14,11 +18,10 @@ module Nandi
       def call
         opts = instruction.extra_args
 
-        Result.new(@instruction).tap do |result|
-          unless opts.key?(:name) || opts.key?(:column)
-            result << "requires a `name` or `column` argument"
-          end
-        end
+        assert(
+          opts.key?(:name) || opts.key?(:column),
+          "remove_index: requires a `name` or `column` argument",
+        )
       end
 
       attr_reader :instruction

--- a/lib/nandi/validation/result.rb
+++ b/lib/nandi/validation/result.rb
@@ -1,35 +1,29 @@
 # frozen_string_literal: true
 
+require "nandi/validation/failure_helpers"
 module Nandi
   module Validation
     class Result
+      include Nandi::Validation::FailureHelpers
+
       attr_reader :errors
 
       def initialize(instruction = nil)
         @instruction = instruction
-        @errors = []
+        @errors = success
       end
 
       def valid?
-        @errors.empty?
+        @errors.success?
       end
 
       def <<(error)
-        error = "#{@instruction.procedure}: #{error}" if @instruction
-        @errors << error
+        @errors = collect_errors(error, @errors)
         self
       end
 
       def error_list
-        @errors.join("\n")
-      end
-
-      def merge(result)
-        result.errors.each do |error|
-          @errors << error
-        end
-
-        self
+        @errors.failure.join("\n")
       end
     end
   end

--- a/lib/nandi/validation/timeout_validator.rb
+++ b/lib/nandi/validation/timeout_validator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "nandi/validation/failure_helpers"
+
+module Nandi
+  module Validation
+    class TimeoutValidator
+      include Nandi::Validation::FailureHelpers
+
+      def self.call(migration)
+        new(migration).call
+      end
+
+      def initialize(migration)
+        @migration = migration
+      end
+
+      def call
+        timeout_policies.inject(success) do |result, policy|
+          collect_errors(policy.validate(migration), result)
+        end
+      end
+
+      private
+
+      def timeout_policies
+        instructions.map(&Nandi::TimeoutPolicies.method(:policy_for)).uniq
+      end
+
+      def instructions
+        [*migration.up_instructions, *migration.down_instructions]
+      end
+
+      attr_reader :migration
+    end
+  end
+end

--- a/nandi.gemspec
+++ b/nandi.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport"
   spec.add_dependency "cells"
+  spec.add_dependency "dry-monads"
   spec.add_dependency "tilt"
 
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/spec/nandi/timeout_policies/access_exclusive_spec.rb
+++ b/spec/nandi/timeout_policies/access_exclusive_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nandi/migration"
+require "nandi/timeout_policies"
+require "nandi/timeout_policies/access_exclusive"
+
+RSpec.describe Nandi::TimeoutPolicies::AccessExclusive do
+  describe "::validate" do
+    subject(:validate) { described_class.validate(migration) }
+
+    let(:migration) do
+      instance_double(Nandi::Migration,
+                      statement_timeout: statement_timeout,
+                      lock_timeout: lock_timeout)
+    end
+
+    before do
+      allow(Nandi.config).to receive(:access_exclusive_statement_timeout_limit).
+        and_return(1500)
+      allow(Nandi.config).to receive(:access_exclusive_lock_timeout_limit).
+        and_return(750)
+    end
+
+    context "with valid timeouts" do
+      let(:statement_timeout) { 1499 }
+      let(:lock_timeout) { 749 }
+
+      it { is_expected.to be_success }
+    end
+
+    context "with too-long statement timeout" do
+      let(:statement_timeout) { 1501 }
+      let(:lock_timeout) { 749 }
+
+      it { is_expected.to be_failure }
+
+      it "yields an informative message" do
+        expect(validate.failure).
+          to eq([
+            "statement timeout must be at most 1500ms" \
+            " as it takes an ACCESS EXCLUSIVE lock",
+          ])
+      end
+    end
+
+    context "with too-long lock timeout" do
+      let(:statement_timeout) { 1499 }
+      let(:lock_timeout) { 751 }
+
+      it { is_expected.to be_failure }
+
+      it "yields an informative message" do
+        expect(validate.failure).
+          to eq([
+            "lock timeout must be at most 750ms as it takes an ACCESS EXCLUSIVE lock",
+          ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Rework the existing validations to use the `Result` type from `dry-monads`.
2. Decouple timeout validations to prepare for minimum timeouts.