### PR TITLE
Move nandiignore logic into FileMatcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nandi (0.7.2)
+    nandi (0.7.3)
       activesupport
       cells
       dry-monads

--- a/lib/nandi.rb
+++ b/lib/nandi.rb
@@ -9,21 +9,8 @@ module Nandi
   class Error < StandardError; end
 
   class << self
-    def ignored_files
-      @ignored_files ||= if File.exist?(".nandiignore")
-                           File.read(".nandiignore").lines.map(&:strip)
-                         else
-                           []
-                         end
-    end
-
-    def ignored_filenames
-      ignored_files.map(&File.method(:basename))
-    end
-
     def compile(files:)
       compiled = files.
-        reject { |f| ignored_filenames.include?(File.basename(f)) }.
         map { |f| CompiledMigration.build(f) }
 
       yield compiled

--- a/lib/nandi/file_matcher.rb
+++ b/lib/nandi/file_matcher.rb
@@ -16,7 +16,9 @@ module Nandi
     def call
       case spec
       when "all"
-        files
+        Set.new(
+          files.reject { |f| ignored_filenames.include?(File.basename(f)) },
+        )
       when "git-diff"
         files.intersection(files_from_git_status)
       when TIMESTAMP_REGEX
@@ -25,6 +27,18 @@ module Nandi
     end
 
     private
+
+    def ignored_files
+      @ignored_files ||= if File.exist?(".nandiignore")
+                           File.read(".nandiignore").lines.map(&:strip)
+                         else
+                           []
+                         end
+    end
+
+    def ignored_filenames
+      ignored_files.map(&File.method(:basename))
+    end
 
     def match_timestamp
       match = TIMESTAMP_REGEX.match(spec)

--- a/nandi.gemspec
+++ b/nandi.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "nandi"
-  spec.version       = "0.7.2"
+  spec.version       = "0.7.3"
   spec.authors       = ["James Turley"]
   spec.email         = ["jamesturley@gocardless.com"]
 

--- a/spec/nandi/file_matcher_spec.rb
+++ b/spec/nandi/file_matcher_spec.rb
@@ -16,10 +16,34 @@ RSpec.describe Nandi::FileMatcher do
       ]
     end
 
+    before do
+      allow(File).to receive(:exist?).with(".nandiignore").and_return(false)
+    end
+
     context "all files" do
       let(:spec) { "all" }
 
       it { is_expected.to eq(Set.new(files)) }
+
+      context "and some files are ignored" do
+        let(:nandiignore) { ignored_files.join("\n") }
+        let(:ignored_files) { ["db/migrate/20190402010101_do_thing_4.rb"] }
+
+        let(:expected) do
+          Set.new([
+            "20180402010101_do_thing_1.rb",
+            "20190101010101_do_thing_2.rb",
+            "20190102010101_do_thing_3.rb",
+          ])
+        end
+
+        before do
+          allow(File).to receive(:exist?).with(".nandiignore").and_return(true)
+          allow(File).to receive(:read).with(".nandiignore").and_return(nandiignore)
+        end
+
+        it { is_expected.to eq(Set.new(expected)) }
+      end
     end
 
     context "git-diff" do

--- a/spec/nandi/safe_migration_enforcer_spec.rb
+++ b/spec/nandi/safe_migration_enforcer_spec.rb
@@ -94,44 +94,6 @@ RSpec.shared_examples "linting" do
         expect(err.message).to_not match(/20190513163423_add_beachballs.rb/)
       end
     end
-
-    context "and the edited file is ignored" do
-      let(:ignored_files) { ar_migration_paths[0..1] }
-
-      it "returns true" do
-        expect(subject.run).to eq(true)
-      end
-    end
-  end
-
-  context "with a .nandiignore file that allows some handwritten migrations" do
-    let(:ignored_files) { ar_migration_paths[0..1] }
-
-    context "and handwritten migrations that are specified in the file" do
-      before do
-        safe_migrations.shift(2)
-      end
-
-      it "returns true" do
-        expect(subject.run).to eq(true)
-      end
-    end
-
-    context "and a handwritten migration that isn't specified in the file" do
-      before do
-        safe_migrations.shift(3)
-      end
-
-      it "raises an error with an appropriate message" do
-        expect { subject.run }.to raise_error do |err|
-          expect(err.class).to eq(Nandi::SafeMigrationEnforcer::MigrationLintingFailed)
-
-          expect(err.message).to match(/20190513163424_add_zoos.rb.*Please use Nandi/m)
-          expect(err.message).to_not match(/20190513163422_add_elephants.rb/)
-          expect(err.message).to_not match(/20190513163423_add_beachballs.rb/)
-        end
-      end
-    end
   end
 end
 
@@ -158,7 +120,6 @@ RSpec.describe Nandi::SafeMigrationEnforcer do
 
   let(:ar_migration_paths) { ar_migrations.map { |f| File.join(ar_migration_dir, f) } }
 
-  let(:ignored_files) { [] }
   let(:lockfile) do
     lockfile_contents = ar_migration_paths.each_with_object({}) do |ar_file, hash|
       file_name = File.basename(ar_file)
@@ -194,8 +155,6 @@ RSpec.describe Nandi::SafeMigrationEnforcer do
 
     allow(File).to receive(:read).with(Regexp.new(ar_migration_dir)).
       and_return("generated_content")
-
-    allow(Nandi).to receive(:ignored_files).and_return(ignored_files)
   end
 
   describe "#run" do

--- a/spec/nandi_spec.rb
+++ b/spec/nandi_spec.rb
@@ -14,60 +14,6 @@ RSpec.describe Nandi do
     allow(Nandi::Lockfile).to receive(:persist!)
   end
 
-  describe "::ignored_files" do
-    subject(:files) { described_class.ignored_files }
-
-    before { described_class.instance_variable_set(:@ignored_files, nil) }
-
-    context "with no .nandiignore" do
-      before do
-        allow(File).to receive(:exist?).with(".nandiignore").
-          and_return(false)
-      end
-
-      it { is_expected.to eq([]) }
-    end
-
-    context "with no .nandiignore" do
-      before do
-        allow(File).to receive(:exist?).with(".nandiignore").
-          and_return(true)
-
-        allow(File).to receive(:read).with(".nandiignore").
-          and_return(["db/migrate/thing1.rb", "db/migrate/thing2.rb"].join("\n"))
-      end
-
-      it { is_expected.to eq(["db/migrate/thing1.rb", "db/migrate/thing2.rb"]) }
-    end
-  end
-
-  describe "::ignored_filenames" do
-    subject(:files) { described_class.ignored_filenames }
-
-    before { described_class.instance_variable_set(:@ignored_files, nil) }
-
-    context "with no .nandiignore" do
-      before do
-        allow(File).to receive(:exist?).with(".nandiignore").
-          and_return(false)
-      end
-
-      it { is_expected.to eq([]) }
-    end
-
-    context "with no .nandiignore" do
-      before do
-        allow(File).to receive(:exist?).with(".nandiignore").
-          and_return(true)
-
-        allow(File).to receive(:read).with(".nandiignore").
-          and_return(["db/migrate/thing1.rb", "db/migrate/thing2.rb"].join("\n"))
-      end
-
-      it { is_expected.to eq(["thing1.rb", "thing2.rb"]) }
-    end
-  end
-
   describe "::compile" do
     let(:args) do
       {
@@ -82,11 +28,7 @@ RSpec.describe Nandi do
       )
     end
 
-    let(:ignored_files) { [] }
-
     before do
-      allow(described_class).to receive(:ignored_files).
-        and_return(ignored_files)
       described_class.configure do |config|
         config.renderer = renderer
       end
@@ -115,19 +57,6 @@ RSpec.describe Nandi do
           Nandi::CompiledMigration::InvalidMigrationError,
           /creating more than one index per migration/,
         )
-      end
-    end
-
-    context "with an ignored migration" do
-      let(:files) { ["#{base_path}/20180104120000_my_migration.rb"] }
-      let(:ignored_files) { files }
-
-      it "does not compile the migration" do
-        expect(renderer).to_not receive(:generate)
-
-        described_class.compile(args) do |output|
-          expect(output).to eq([])
-        end
       end
     end
 


### PR DESCRIPTION
Removes duplication across compiler and enforcer - also fixes a bug where the enforcer was not ignoring the right things. 