### PR TITLE
Change example instructions in template

### DIFF
--- a/lib/generators/nandi/migration/templates/migration.rb
+++ b/lib/generators/nandi/migration/templates/migration.rb
@@ -3,11 +3,11 @@
 class <%= class_name %> < Nandi::Migration
   def up
     # Migration instructions go here, eg:
-    # add_index :payments, [:foo, :bar]
+    # add_column :widgets, :size, :integer
   end
 
   def down
     # Reverse migration instructions go here, eg:
-    # remove_index :payments, :index_payments_on_foo_bar
+    # remove_column :widgets, :size
   end
 end


### PR DESCRIPTION
Because:

1. The down instruction is actually invalid (it passes the index name to the columns positional arg)
2. Creating/removing columns is a more common case; we had adding an index simply because it was the first one we did.