### PR TITLE
Do not validate migrations that will not be recompiled

### DIFF
--- a/lib/nandi/compiled_migration.rb
+++ b/lib/nandi/compiled_migration.rb
@@ -9,7 +9,7 @@ module Nandi
     attr_reader :file_name, :source_file_path, :class_name
 
     def self.build(source_file_path)
-      new(source_file_path).validate!
+      new(source_file_path)
     end
 
     def initialize(source_file_path)
@@ -34,6 +34,7 @@ module Nandi
       @body ||= if migration_unchanged?
                   File.read(output_path)
                 else
+                  validate!
                   compiled_body
                 end
     end

--- a/spec/nandi/compiled_migration_spec.rb
+++ b/spec/nandi/compiled_migration_spec.rb
@@ -48,19 +48,6 @@ RSpec.describe Nandi::CompiledMigration do
     end
   end
 
-  describe "::build" do
-    context "invalid migration" do
-      let(:file) { invalid_migration }
-
-      it "raises an InvalidMigrationError" do
-        expect { described_class.build(file) }.to raise_error(
-          described_class::InvalidMigrationError,
-          /creating more than one index per migration/,
-        )
-      end
-    end
-  end
-
   describe "#body" do
     subject(:body) { described_class.new(file).body }
 
@@ -75,6 +62,17 @@ RSpec.describe Nandi::CompiledMigration do
         end
 
         body
+      end
+    end
+
+    context "invalid migration" do
+      let(:file) { invalid_migration }
+
+      it "raises an InvalidMigrationError" do
+        expect { body }.to raise_error(
+          described_class::InvalidMigrationError,
+          /creating more than one index per migration/,
+        )
       end
     end
 

--- a/spec/nandi_spec.rb
+++ b/spec/nandi_spec.rb
@@ -47,19 +47,6 @@ RSpec.describe Nandi do
       end
     end
 
-    context "with an invalid migration" do
-      let(:files) { ["#{base_path}/20180104120000_my_invalid_migration.rb"] }
-
-      it "throws an invalid migration error" do
-        expect do
-          described_class.compile(args) { |_| nil }
-        end.to raise_error(
-          Nandi::CompiledMigration::InvalidMigrationError,
-          /creating more than one index per migration/,
-        )
-      end
-    end
-
     context "with a post-processing step" do
       let(:files) { ["#{base_path}/20180104120000_my_migration.rb"] }
 


### PR DESCRIPTION
Greedily validating meant that old index creates with more modest lock timeouts were causing nandi:compile to fail.