### PR TITLE
Use current Rails migration class version

### DIFF
--- a/lib/nandi/renderers/active_record/generate.rb
+++ b/lib/nandi/renderers/active_record/generate.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record"
 require "cell"
 require "tilt"
 require "nandi/renderers/active_record/instructions"
@@ -30,6 +31,10 @@ module Nandi
         def should_disable_ddl_transaction?
           [*up_instructions, *down_instructions].
             select { |i| i.procedure =~ /index/ }.any?
+        end
+
+        def activerecord_version
+          ::ActiveRecord::Migration.current_version
         end
 
         def render_partial(instruction)

--- a/lib/templates/nandi/renderers/active_record/generate/show.rb.erb
+++ b/lib/templates/nandi/renderers/active_record/generate/show.rb.erb
@@ -1,4 +1,4 @@
-class <%= name %> < ActiveRecord::Migration[5.2]
+class <%= name %> < ActiveRecord::Migration[<%= activerecord_version %>]
   <%= mixins.map { |m| "include #{m.name}"}.join("\n") %>
   <% if disable_lock_timeout? %>
   disable_lock_timeout!


### PR DESCRIPTION
I was convinced I did this ages ago ... but apparently not. 🤷‍♂ 