### PR TITLE
Mark method_missing as ruby2_keywords

### DIFF
--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -363,6 +363,7 @@ module Nandi
         super
       end
     end
+    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     private
 

--- a/lib/nandi/version.rb
+++ b/lib/nandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nandi
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
From updating our project for Ruby 2.7 we saw this deprecation notice:

```
/home/circleci/project/vendor/bundle/ruby/2.7.0/gems/nandi-0.9.0/lib/nandi/migration.rb:360: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/circleci/project/some_extension.rb:65: warning: The called method `initialize' is defined here
```

See https://ruby-doc.org/core-2.7.1/Module.html#method-i-ruby2_keywords 