### PR TITLE
Allow creation of hash indices with Nandi

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,13 @@ RSpec/ContextWording:
 RSpec/AnyInstance:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 20
+
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - 'nandi.gemspec'
+
 Naming/MethodParameterName:
   AllowedNames:
     # These are the default allowed names, set by Rubocop

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Adds a new index to the database.
 Nandi will:
 
 - add the `CONCURRENTLY` option, which means the change takes a less restrictive lock at the cost of not running in a DDL transaction
-- use the `BTREE` index type which is the safest to create.
+- enforce the index type is either `BTREE` or `HASH`. defaulting to the `BTREE` index type, as they are the safest to create.
 
 Because index creation is particularly failure-prone, and because we cannot run in a transaction and therefore risk partially applied migrations that (in a Rails environment) require manual intervention, Nandi Validates that, if there is a add_index statement in the migration, it must be the only statement.
 

--- a/lib/nandi/instructions/add_index.rb
+++ b/lib/nandi/instructions/add_index.rb
@@ -21,11 +21,10 @@ module Nandi
           name: name,
 
           # Overrides and extra options
-          **@extra_args,
+          **extra_args_with_default_index_type,
 
           # Mandatory values
           algorithm: :concurrently,
-          using: :btree,
         }
       end
 
@@ -44,6 +43,12 @@ module Nandi
       def field_names
         field_names = fields.respond_to?(:map) ? fields.map(&:to_s).join("_") : fields
         field_names.to_s.scan(/\w+/).join("_")
+      end
+
+      def extra_args_with_default_index_type
+        {
+          using: :btree,
+        }.merge(@extra_args)
       end
     end
   end

--- a/lib/nandi/validation.rb
+++ b/lib/nandi/validation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "nandi/validation/add_column_validator"
+require "nandi/validation/add_index_validator"
 require "nandi/validation/add_reference_validator"
 require "nandi/validation/remove_index_validator"
 require "nandi/validation/each_validator"

--- a/lib/nandi/validation/add_index_validator.rb
+++ b/lib/nandi/validation/add_index_validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "nandi/validation/failure_helpers"
+
+module Nandi
+  module Validation
+    class AddIndexValidator
+      include Nandi::Validation::FailureHelpers
+
+      VALID_INDEX_TYPES = %i[btree hash].freeze
+
+      def self.call(instruction)
+        new(instruction).call
+      end
+
+      def initialize(instruction)
+        @instruction = instruction
+      end
+
+      def call
+        opts = instruction.extra_args
+
+        return unless opts.key?(:using)
+
+        assert(
+          VALID_INDEX_TYPES.include?(opts.fetch(:using)),
+          "add_index: index type can only be one of #{VALID_INDEX_TYPES}",
+        )
+      end
+
+      attr_reader :instruction
+    end
+  end
+end

--- a/lib/nandi/validation/each_validator.rb
+++ b/lib/nandi/validation/each_validator.rb
@@ -21,6 +21,8 @@ module Nandi
           RemoveIndexValidator.call(instruction)
         when :add_column
           AddColumnValidator.call(instruction)
+        when :add_index
+          AddIndexValidator.call(instruction)
         when :add_reference
           AddReferenceValidator.call(instruction)
         else

--- a/spec/nandi/compiled_migration_spec.rb
+++ b/spec/nandi/compiled_migration_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe Nandi::CompiledMigration do
 
   let(:valid_migration) { "#{base_path}/20180104120000_my_migration.rb" }
   let(:invalid_migration) { "#{base_path}/20180104120000_my_invalid_migration.rb" }
+  let(:invalid_index_migration) do
+    "#{base_path}/20180104120000_my_invalid_index_migration.rb"
+  end
 
   let(:source_contents) { "source_migration" }
   let(:compiled_contents) { "compiled_migration" }
@@ -72,6 +75,17 @@ RSpec.describe Nandi::CompiledMigration do
         expect { body }.to raise_error(
           described_class::InvalidMigrationError,
           /creating more than one index per migration/,
+        )
+      end
+    end
+
+    context "invalid index migration" do
+      let(:file) { invalid_index_migration }
+
+      it "raises an InvalidMigrationError" do
+        expect { body }.to raise_error(
+          described_class::InvalidMigrationError,
+          /add_index: index type can only be one of \[:btree, :hash\]/,
         )
       end
     end

--- a/spec/nandi/fixtures/example_migrations/20180104120000_my_invalid_index_migration.rb
+++ b/spec/nandi/fixtures/example_migrations/20180104120000_my_invalid_index_migration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MyInvalidIndexMigration < Nandi::Migration
+  def up
+    add_index :payments, :foo, using: :gin
+  end
+
+  def down
+    remove_index :payments, :foo
+  end
+end

--- a/spec/nandi/fixtures/rendered/active_record/create_and_drop_index_timeouts.rb
+++ b/spec/nandi/fixtures/rendered/active_record/create_and_drop_index_timeouts.rb
@@ -15,8 +15,8 @@ class MyAwesomeMigration < ActiveRecord::Migration[5.2]
   [:foo, :bar],
   {
   name: :idx_payments_on_foo_bar,
-  algorithm: :concurrently,
-  using: :btree
+  using: :btree,
+  algorithm: :concurrently
 }
 )
 

--- a/spec/nandi/fixtures/rendered/active_record/create_and_drop_index_with_hash.rb
+++ b/spec/nandi/fixtures/rendered/active_record/create_and_drop_index_with_hash.rb
@@ -15,7 +15,7 @@ class MyAwesomeMigration < ActiveRecord::Migration[5.2]
   [:foo, :bar],
   {
   name: :idx_payments_on_foo_bar,
-  using: :btree,
+  using: :hash,
   algorithm: :concurrently
 }
 )

--- a/spec/nandi/instructions/add_index_spec.rb
+++ b/spec/nandi/instructions/add_index_spec.rb
@@ -83,8 +83,20 @@ RSpec.describe Nandi::Instructions::AddIndex do
       end
     end
 
-    context "with custom algorithm and using values" do
-      let(:extra_args) { { algorithm: :paxos, using: :gin } }
+    context "with custom using" do
+      let(:extra_args) { { using: :hash } }
+
+      it "allows override" do
+        expect(args).to eq(
+          algorithm: :concurrently,
+          using: :hash,
+          name: :idx_widgets_on_foo,
+        )
+      end
+    end
+
+    context "with custom algorithm" do
+      let(:extra_args) { { algorithm: :paxos } }
 
       it "does not allow override" do
         expect(args).to eq(


### PR DESCRIPTION
Rather than defaulting to `BTREE` indices allow creation of `BTREE` or `HASH` indices.

[Pre Postgres 10 Hash indices were recommended against, however this has changed from PG 10 onwards](https://medium.com/@jorsol/postgresql-10-features-hash-indexes-484f319db281).