### PR TITLE
Allow `brin` indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Adds a new index to the database.
 Nandi will:
 
 - add the `CONCURRENTLY` option, which means the change takes a less restrictive lock at the cost of not running in a DDL transaction
-- enforce the index type is either `BTREE` or `HASH`. defaulting to the `BTREE` index type, as they are the safest to create.
+- enforce the index type is either `BTREE`, `HASH`, or `BRIN`. defaulting to the `BTREE` index type, as they are the safest to create.
 
 Because index creation is particularly failure-prone, and because we cannot run in a transaction and therefore risk partially applied migrations that (in a Rails environment) require manual intervention, Nandi Validates that, if there is a add_index statement in the migration, it must be the only statement.
 

--- a/lib/nandi/validation/add_index_validator.rb
+++ b/lib/nandi/validation/add_index_validator.rb
@@ -7,7 +7,7 @@ module Nandi
     class AddIndexValidator
       include Nandi::Validation::FailureHelpers
 
-      VALID_INDEX_TYPES = %i[btree hash].freeze
+      VALID_INDEX_TYPES = %i[btree hash brin].freeze
 
       def self.call(instruction)
         new(instruction).call

--- a/spec/nandi/compiled_migration_spec.rb
+++ b/spec/nandi/compiled_migration_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Nandi::CompiledMigration do
       it "raises an InvalidMigrationError" do
         expect { body }.to raise_error(
           described_class::InvalidMigrationError,
-          /add_index: index type can only be one of \[:btree, :hash\]/,
+          /add_index: index type can only be one of \[:btree, :hash, :brin\]/,
         )
       end
     end


### PR DESCRIPTION
I would like to try out [`brin` indexes](https://www.postgresql.org/docs/9.5/brin-intro.html) in banking_integrations: I think I have a good use case for it.

From what I have read, BRIN is great for filtering out large ranges of data in large tables which have monotonically increasing static values, so I think it would be a good candidate on indexing on `created_at`, which currently usually does a seq scan.