### PR TITLE
This one weird trick to avoid merge conflicts

### DIFF
--- a/spec/nandi/lockfile_spec.rb
+++ b/spec/nandi/lockfile_spec.rb
@@ -116,5 +116,37 @@ RSpec.describe Nandi::Lockfile do
 
       persist!
     end
+
+    context "with multiple keys, not sorted by their SHA-256 hash" do
+      let(:expected_yaml) do
+        <<~YAML
+          ---
+          lower_hash:
+            foo: 5
+          higher_hash:
+            foo: 5
+        YAML
+      end
+
+      before do
+        described_class.lockfile = {
+          higher_hash: {
+            foo: 5,
+          },
+          lower_hash: {
+            foo: 5,
+          },
+        }
+      end
+
+      it "sorts the keys by their SHA-256 hash" do
+        expect(File).to receive(:write).with(
+          "db/.nandilock.yml",
+          expected_yaml,
+        )
+
+        persist!
+      end
+    end
   end
 end


### PR DESCRIPTION
@tragiclifestories @paprikati @isaacseymour: After our discussion in Slack I thought I'd have a go at this.

Explanation of what's going on is in a big comment above the relevant test.

Rubocop is sad in CI, and wants us to remove Ruby 2.4 as we no longer support it. Given it's [run out of security support](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/) I'm in favour of totally removing it in a separate PR (from the Circle build matrix too).

Don't think this needs a major version bump. Nothing will actually break. People using the library will get one PR where the ordering changes, so we should changelog it.