### PR TITLE
Pass kwargs on to custom classes

### DIFF
--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -357,9 +357,9 @@ module Nandi
       end.uniq
     end
 
-    def method_missing(name, *args, &block)
+    def method_missing(name, *args, **kwargs, &block)
       if Nandi.config.custom_methods.key?(name)
-        invoke_custom_method(name, *args, &block)
+        invoke_custom_method(name, *args, **kwargs, &block)
       else
         super
       end
@@ -381,9 +381,9 @@ module Nandi
       Nandi.config.access_exclusive_lock_timeout
     end
 
-    def invoke_custom_method(name, *args, &block)
+    def invoke_custom_method(name, *args, **kwargs, &block)
       klass = Nandi.config.custom_methods[name]
-      current_instructions << klass.new(*args, &block)
+      current_instructions << klass.new(*args, **kwargs, &block)
     end
   end
 end

--- a/lib/nandi/version.rb
+++ b/lib/nandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nandi
-  VERSION = "0.11.2"
+  VERSION = "0.11.3"
 end

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -851,7 +851,14 @@ RSpec.describe Nandi::Migration do
     end
 
     let(:extension) do
-      Struct.new(:foo, :bar) do
+      Class.new do
+        attr_reader :foo, :bar
+
+        def initialize(foo, bar, **_kwargs)
+          @foo = foo
+          @bar = bar
+        end
+
         def procedure
           :new_method
         end

--- a/spec/nandi/renderers/active_record_spec.rb
+++ b/spec/nandi/renderers/active_record_spec.rb
@@ -398,7 +398,14 @@ RSpec.describe Nandi::Renderers::ActiveRecord do
       end
 
       let(:extension) do
-        Struct.new(:foo, :bar) do
+        Class.new do
+          attr_reader :foo, :bar
+
+          def initialize(foo, bar, **_kwargs)
+            @foo = foo
+            @bar = bar
+          end
+
           def procedure
             :new_method
           end
@@ -449,7 +456,14 @@ RSpec.describe Nandi::Renderers::ActiveRecord do
         end
 
         let(:extension) do
-          Struct.new(:foo, :bar) do
+          Class.new do
+            attr_reader :foo, :bar
+
+            def initialize(foo, bar, **_kwargs)
+              @foo = foo
+              @bar = bar
+            end
+
             def procedure
               :new_method
             end
@@ -521,7 +535,7 @@ RSpec.describe Nandi::Renderers::ActiveRecord do
               :new_method
             end
 
-            def initialize
+            def initialize(**_kwargs)
               @block_result = yield
             end
 


### PR DESCRIPTION
Running this under ruby 2.7 leads to a deprecation warning:

```
DEPRECATION WARNING: nandi/lib/nandi/migration.rb:362: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
nandi/lib/nandi/migration.rb:384: warning: The called method `invoke_custom_method' is defined here
```﻿
