### PR TITLE
Add "prettier" to gemspec

### DIFF
--- a/nandi.gemspec
+++ b/nandi.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cells"
   spec.add_dependency "dry-monads"
   spec.add_dependency "tilt"
+  spec.add_dependency "prettier", "= 1.6.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "byebug", "~> 11.0"


### PR DESCRIPTION
I noticed that with version `2.0.0` of `prettier` installed (on [Skyhook](https://github.com/gocardless/skyhook)), nandi generate generates a blank migration.
If I pin the version to `1.6.1`, the issue is resolved