### PR TITLE
Prevent the creation of hash indexes using Nandi.

### DIFF
--- a/lib/nandi/validation/add_index_validator.rb
+++ b/lib/nandi/validation/add_index_validator.rb
@@ -17,7 +17,7 @@ module Nandi
 
       def call
         assert(
-          !using_hash_index?,
+          not_using_hash_index?,
           "add_index: Nandi does not support hash indexes. Hash indexes typically have "\
           "very specialized use cases. Please revert to using a btree index, or proceed "\
           "with the creation of this index without using Nandi.",
@@ -28,8 +28,8 @@ module Nandi
 
       private
 
-      def using_hash_index?
-        instruction.extra_args[:using] == :hash
+      def not_using_hash_index?
+        instruction.extra_args[:using] != :hash
       end
     end
   end

--- a/lib/nandi/validation/add_index_validator.rb
+++ b/lib/nandi/validation/add_index_validator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "nandi/validation/failure_helpers"
+
+module Nandi
+  module Validation
+    class AddIndexValidator
+      include Nandi::Validation::FailureHelpers
+
+      def self.call(instruction)
+        new(instruction).call
+      end
+
+      def initialize(instruction)
+        @instruction = instruction
+      end
+
+      def call
+        assert(
+          !using_hash_index?,
+          "add_index: Nandi does not support hash indexes. Hash indexes typically have very specialized use cases.
+           Please revert to using a btree index, or proceed with the creation of this index without using Nandi.",
+        )
+      end
+
+      attr_reader :instruction
+
+      private
+
+      def using_hash_index?
+        instruction.extra_args[:using] == :hash
+      end
+    end
+  end
+end

--- a/lib/nandi/validation/add_index_validator.rb
+++ b/lib/nandi/validation/add_index_validator.rb
@@ -18,8 +18,9 @@ module Nandi
       def call
         assert(
           !using_hash_index?,
-          "add_index: Nandi does not support hash indexes. Hash indexes typically have very specialized use cases.
-           Please revert to using a btree index, or proceed with the creation of this index without using Nandi.",
+          "add_index: Nandi does not support hash indexes. Hash indexes typically have "\
+          "very specialized use cases. Please revert to using a btree index, or proceed "\
+          "with the creation of this index without using Nandi.",
         )
       end
 

--- a/lib/nandi/validation/each_validator.rb
+++ b/lib/nandi/validation/each_validator.rb
@@ -17,6 +17,8 @@ module Nandi
 
       def call
         case instruction.procedure
+        when :add_index
+          AddIndexValidator.call(instruction)
         when :remove_index
           RemoveIndexValidator.call(instruction)
         when :add_column

--- a/spec/nandi/formatting_spec.rb
+++ b/spec/nandi/formatting_spec.rb
@@ -147,8 +147,11 @@ RSpec.describe Nandi::Formatting do
       end
     end
 
+    # Define a custom class with the desired attributes
+    let(:my_hash) { Struct.new(:my_hash) }
+
     let(:model) do
-      ::Struct.new(:my_hash).new(:foo => { bar: 5 })
+      my_hash.new(foo: { bar: 5 })
     end
 
     it { is_expected.to eq("{\n  foo: {\n  bar: 5\n}\n}") }

--- a/spec/nandi/formatting_spec.rb
+++ b/spec/nandi/formatting_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Nandi::Formatting do
     end
 
     let(:model) do
-      Struct.new(:my_hash).new(foo: { bar: 5 })
+      Struct.new(:my_hash).new(:foo => { bar: 5 })
     end
 
     it { is_expected.to eq("{\n  foo: {\n  bar: 5\n}\n}") }

--- a/spec/nandi/formatting_spec.rb
+++ b/spec/nandi/formatting_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Nandi::Formatting do
     end
 
     let(:model) do
-      Struct.new(:my_hash).new({foo: { bar: 5 }})
+      Struct.new(:my_hash).new({ foo: { bar: 5 } })
     end
 
     it { is_expected.to eq("{\n  foo: {\n  bar: 5\n}\n}") }

--- a/spec/nandi/formatting_spec.rb
+++ b/spec/nandi/formatting_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Nandi::Formatting do
     end
 
     let(:model) do
-      Struct.new(:my_hash).new(:foo => { bar: 5 })
+      ::Struct.new(:my_hash).new(:foo => { bar: 5 })
     end
 
     it { is_expected.to eq("{\n  foo: {\n  bar: 5\n}\n}") }

--- a/spec/nandi/formatting_spec.rb
+++ b/spec/nandi/formatting_spec.rb
@@ -147,11 +147,8 @@ RSpec.describe Nandi::Formatting do
       end
     end
 
-    # Define a custom class with the desired attributes
-    let(:my_hash) { Struct.new(:my_hash) }
-
     let(:model) do
-      my_hash.new(foo: { bar: 5 })
+      Struct.new(:my_hash).new({foo: { bar: 5 }})
     end
 
     it { is_expected.to eq("{\n  foo: {\n  bar: 5\n}\n}") }

--- a/spec/nandi/validation/add_index_validator_spec.rb
+++ b/spec/nandi/validation/add_index_validator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nandi/validation/add_index_validator"
+require "nandi/migration"
+require "nandi/instructions"
+
+RSpec.describe Nandi::Validation::AddIndexValidator do
+  subject(:validator) { described_class.call(instruction) }
+
+  describe "with a hash index in the contained migration" do
+    let(:instruction) do
+      Nandi::Instructions::AddIndex.new(
+        table: :payments,
+        fields: [:foo],
+        using: :hash,
+      )
+    end
+
+    it { is_expected.to be_failure }
+  end
+
+  describe "without a hash index in the contained migration" do
+    let(:instruction) do
+      Nandi::Instructions::AddIndex.new(
+        table: :payments,
+        fields: [:foo],
+      )
+    end
+
+    it { is_expected.to be_success }
+  end
+end

--- a/spec/nandi/validation/each_validator_spec.rb
+++ b/spec/nandi/validation/each_validator_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Nandi::Validation::EachValidator do
       end
 
       it "calls RemoveIndexValidator" do
-        expect(Nandi::Validation::RemoveIndexValidator).to receive(:call).with(instruction)
+        expect(Nandi::Validation::RemoveIndexValidator).to receive(:call).
+          with(instruction)
 
         call
       end
@@ -46,7 +47,8 @@ RSpec.describe Nandi::Validation::EachValidator do
       end
 
       it "calls AddReferenceValidator" do
-        expect(Nandi::Validation::AddReferenceValidator).to receive(:call).with(instruction)
+        expect(Nandi::Validation::AddReferenceValidator).to receive(:call).
+          with(instruction)
 
         call
       end
@@ -60,7 +62,8 @@ RSpec.describe Nandi::Validation::EachValidator do
       end
 
       it "calls AddIndexValidator" do
-        expect(Nandi::Validation::AddIndexValidator).to receive(:call).with(instruction)
+        expect(Nandi::Validation::AddIndexValidator).to receive(:call).
+          with(instruction)
 
         call
       end

--- a/spec/nandi/validation/each_validator_spec.rb
+++ b/spec/nandi/validation/each_validator_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nandi/validation/add_index_validator"
+require "nandi/validation/remove_index_validator"
+require "nandi/migration"
+require "nandi/instructions"
+
+RSpec.describe Nandi::Validation::EachValidator do
+  subject(:call) { described_class.call(instruction) }
+
+  describe "#call" do
+    context "when the given instruction is to remove an index" do
+      let(:instruction) { instance_double(Nandi::Instructions::RemoveIndex) }
+
+      before do
+        allow(instruction).to receive(:procedure).and_return(:remove_index)
+      end
+
+      it "calls RemoveIndexValidator" do
+        expect(Nandi::Validation::RemoveIndexValidator).to receive(:call).with(instruction)
+
+        call
+      end
+    end
+
+    context "when the given instruction is to add a column" do
+      let(:instruction) { instance_double(Nandi::Instructions::AddColumn) }
+
+      before do
+        allow(instruction).to receive(:procedure).and_return(:add_column)
+      end
+
+      it "calls AddColumnValidator" do
+        expect(Nandi::Validation::AddColumnValidator).to receive(:call).with(instruction)
+
+        call
+      end
+    end
+
+    context "when the given instruction is to add a reference" do
+      let(:instruction) { instance_double(Nandi::Instructions::AddReference) }
+
+      before do
+        allow(instruction).to receive(:procedure).and_return(:add_reference)
+      end
+
+      it "calls AddReferenceValidator" do
+        expect(Nandi::Validation::AddReferenceValidator).to receive(:call).with(instruction)
+
+        call
+      end
+    end
+
+    context "when the given instruction is to add an index" do
+      let(:instruction) { instance_double(Nandi::Instructions::AddIndex) }
+
+      before do
+        allow(instruction).to receive(:procedure).and_return(:add_index)
+      end
+
+      it "calls AddIndexValidator" do
+        expect(Nandi::Validation::AddIndexValidator).to receive(:call).with(instruction)
+
+        call
+      end
+    end
+
+    context "when the given instruction isn't explicitly validated" do
+      let(:instruction) { instance_double(Nandi::Instructions::AddForeignKey) }
+
+      before do
+        allow(instruction).to receive(:procedure).and_return(:add_foreign_key)
+      end
+
+      it "returns successful" do
+        expect(call).to eq(Dry::Monads::Result::Success.new(nil))
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,6 @@ require "bundler/setup"
 require "pathname"
 require "nandi"
 
-# Always handy to have in tests
-require "pry"
-
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
The creation of a hash index on a low cardinality column recently resulted in degraded performance across the platform because it was applied to a table column with a low number of distinct values. This resulted in an ever-increasing number of hash collisions during the creation of the index, culminating in an extremely long-running query that prevented Postgres from auto-vacuuming dead tuples and eventually bringing database activity to a near-standstill.

As a result, it's been agreed that we will explicitly disallow the creation of hash indexes using Nandi. Whilst not entirely preventing the creation of hash indexes, this adds another hurdle to creating one as you'll need to create a migration outside of Nandi.