### PR TITLE
Fix `AddIndexValidator` error

### DIFF
--- a/lib/nandi/validation.rb
+++ b/lib/nandi/validation.rb
@@ -2,6 +2,7 @@
 
 require "nandi/validation/add_column_validator"
 require "nandi/validation/add_reference_validator"
+require "nandi/validation/add_index_validator"
 require "nandi/validation/remove_index_validator"
 require "nandi/validation/each_validator"
 require "nandi/validation/result"


### PR DESCRIPTION
Adding a new index using `add_index` resulted in error:
```
uninitialized constant Nandi::Validation::EachValidator::AddIndexValidator (NameError)

     AddIndexValidator.call(instruction)
     ^^^^^^^^^^^^^^^^^
Did you mean? Nandi::Validation::AddColumnValidator
```

The `AddIndexValidator` wasn't imported in the `validation.rb`.