### PR TITLE
Allow idempotent database registration for Rails reloading

### DIFF
--- a/lib/nandi/multi_database.rb
+++ b/lib/nandi/multi_database.rb
@@ -54,13 +54,14 @@ module Nandi
       # @return [String]
       attr_accessor :output_directory
 
-      attr_reader :name, :default
+      attr_reader :name, :default, :raw_config
 
       attr_accessor :migration_directory,
                     :lockfile_name
 
       def initialize(name:, config:)
         @name = name
+        @raw_config = config
         @default = @name == :primary || config[:default] == true
 
         # Paths and files
@@ -115,6 +116,10 @@ module Nandi
 
     def register(name, config)
       name = name.to_sym
+
+      # Allow re-registration with identical config (for Rails reloading)
+      return @databases[name] if @databases.key?(name) && @databases[name].raw_config == config
+
       raise ArgumentError, "Database #{name} already registered" if @databases.key?(name)
 
       @databases[name] = Database.new(name: name, config: config)

--- a/lib/nandi/version.rb
+++ b/lib/nandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nandi
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/spec/nandi/multi_database_spec.rb
+++ b/spec/nandi/multi_database_spec.rb
@@ -54,10 +54,23 @@ RSpec.describe Nandi::MultiDatabase do
       expect(multi_db.default.name).to eq(:primary)
     end
 
-    it "raises error for duplicate database registration" do
+    it "raises error for duplicate database registration with different config" do
       expect do
         multi_db.register(:primary, migration_directory: "db/new")
       end.to raise_error(ArgumentError, "Database primary already registered")
+    end
+
+    it "allows re-registration with identical config (for Rails reloading)" do
+      original_config = { migration_directory: "db/safe_migrations", output_directory: "db/migrate" }
+
+      # First registration
+      db1 = multi_db.register(:reloadable, original_config)
+
+      # Re-registration with same config should return the same database object
+      db2 = multi_db.register(:reloadable, original_config)
+
+      expect(db2).to eq(db1)
+      expect(multi_db.names.count(:reloadable)).to eq(1)
     end
 
     it "converts string names to symbols" do


### PR DESCRIPTION
## Summary
- Fixes an issue where Rails code reloading would fail with "Database already registered" error
- Makes database registration idempotent when called with identical configuration
- Maintains backward compatibility by still raising errors for conflicting configurations

## Problem
When using Nandi 2.0.0 with Rails' `Rails.application.reloader.to_prepare` callback, the databases would be registered multiple times during code reloading in development. This causes the application to crash with:
```
ArgumentError: Database primary already registered
```

This particularly affects development environments where code reloading is essential for productivity.

## Solution
Modified `MultiDatabase#register` to:
1. Store the raw configuration hash in each Database instance
2. Check if a database is already registered with the same configuration
3. If yes, return the existing database object (idempotent behavior)
4. If no (different config), raise the original error to maintain backward compatibility

## Testing
- Added a new spec to verify idempotent registration works correctly
- Existing specs continue to pass, confirming backward compatibility
- Manually tested with Rails application using `Rails.application.reloader.reload!`

## Impact
- No breaking changes for existing users
- Enables smooth Rails development experience with code reloading
- Particularly important for applications upgrading to Nandi 2.0.0

🤖 Generated with [Claude Code](https://claude.ai/code)