### PR TITLE
Add concurrent_lock_timeout and concurrent_statement_timeout global config

### DIFF
--- a/lib/nandi/config.rb
+++ b/lib/nandi/config.rb
@@ -78,6 +78,8 @@ module Nandi
     def access_exclusive_statement_timeout_limit(database_name = nil) = config(database_name).access_exclusive_statement_timeout_limit
     def concurrent_lock_timeout_limit(database_name = nil) = config(database_name).concurrent_lock_timeout_limit
     def concurrent_statement_timeout_limit(database_name = nil) = config(database_name).concurrent_statement_timeout_limit
+    def concurrent_lock_timeout(database_name = nil) = config(database_name).concurrent_lock_timeout
+    def concurrent_statement_timeout(database_name = nil) = config(database_name).concurrent_statement_timeout
     # rubocop:enable Layout/LineLength
 
     # Delegate setter methods to the default database for backwards compatibility
@@ -89,6 +91,8 @@ module Nandi
              :access_exclusive_statement_timeout_limit=,
              :concurrent_lock_timeout_limit=,
              :concurrent_statement_timeout_limit=,
+             :concurrent_lock_timeout=,
+             :concurrent_statement_timeout=,
              to: :default
 
     delegate :validate!, :default, :config, to: :databases

--- a/lib/nandi/instructions/add_index.rb
+++ b/lib/nandi/instructions/add_index.rb
@@ -41,7 +41,7 @@ module Nandi
       end
 
       def field_names
-        field_names = fields.respond_to?(:map) ? fields.map(&:to_s).join("_") : fields
+        field_names = fields.respond_to?(:map) ? fields.join("_") : fields
         field_names.to_s.scan(/\w+/).join("_")
       end
 

--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -329,7 +329,7 @@ module Nandi
 
     def disable_lock_timeout?
       if self.class.lock_timeout.nil?
-        strictest_lock == LockWeights::SHARE
+        strictest_lock == LockWeights::SHARE && Nandi.config.concurrent_lock_timeout.nil?
       else
         false
       end
@@ -337,7 +337,7 @@ module Nandi
 
     def disable_statement_timeout?
       if self.class.statement_timeout.nil?
-        strictest_lock == LockWeights::SHARE
+        strictest_lock == LockWeights::SHARE && Nandi.config.concurrent_statement_timeout.nil?
       else
         false
       end
@@ -374,11 +374,11 @@ module Nandi
     end
 
     def default_statement_timeout
-      Nandi.config.access_exclusive_statement_timeout
+      Nandi.config.concurrent_statement_timeout || Nandi.config.access_exclusive_statement_timeout
     end
 
     def default_lock_timeout
-      Nandi.config.access_exclusive_lock_timeout
+      Nandi.config.concurrent_lock_timeout || Nandi.config.access_exclusive_lock_timeout
     end
 
     def invoke_custom_method(name, ...)

--- a/lib/nandi/multi_database.rb
+++ b/lib/nandi/multi_database.rb
@@ -50,6 +50,18 @@ module Nandi
       # @return [Integer]
       attr_accessor :concurrent_lock_timeout_limit
 
+      # The default lock timeout for migrations that take place concurrently
+      # (eg. add_index, remove_index). When set, concurrent migrations will use
+      # set_lock_timeout instead of disable_lock_timeout!. Default: nil (disabled).
+      # @return [Integer, nil]
+      attr_accessor :concurrent_lock_timeout
+
+      # The default statement timeout for migrations that take place concurrently
+      # (eg. add_index, remove_index). When set, concurrent migrations will use
+      # set_statement_timeout instead of disable_statement_timeout!. Default: nil (disabled).
+      # @return [Integer, nil]
+      attr_accessor :concurrent_statement_timeout
+
       # The directory for output files. Default: `db/migrate`
       # @return [String]
       attr_accessor :output_directory
@@ -87,6 +99,8 @@ module Nandi
           config[:concurrent_lock_timeout_limit] || DEFAULT_CONCURRENT_TIMEOUT_LIMIT
         @concurrent_statement_timeout_limit =
           config[:concurrent_statement_timeout_limit] || DEFAULT_CONCURRENT_TIMEOUT_LIMIT
+        @concurrent_lock_timeout = config[:concurrent_lock_timeout]
+        @concurrent_statement_timeout = config[:concurrent_statement_timeout]
       end
 
       def path_prefix(name, default)

--- a/lib/nandi/version.rb
+++ b/lib/nandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nandi
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -940,9 +940,84 @@ RSpec.describe Nandi::Migration do
           end
         end
 
-        it "disables only the lock timeout" do
+        it "disables only the statement timeout" do
           expect(migration.disable_lock_timeout?).to be(false)
           expect(migration.disable_statement_timeout?).to be(true)
+        end
+      end
+
+      context "and concurrent_lock_timeout is configured globally" do
+        before { allow(Nandi.config).to receive(:concurrent_lock_timeout).and_return(120_000) }
+        after { allow(Nandi.config).to receive(:concurrent_lock_timeout).and_call_original }
+
+        it "does not disable the lock timeout" do
+          expect(migration.disable_lock_timeout?).to be(false)
+        end
+
+        it "uses the configured concurrent lock timeout" do
+          expect(migration.lock_timeout).to eq(120_000)
+        end
+
+        it "still disables the statement timeout" do
+          expect(migration.disable_statement_timeout?).to be(true)
+        end
+      end
+
+      context "and concurrent_statement_timeout is configured globally" do
+        before { allow(Nandi.config).to receive(:concurrent_statement_timeout).and_return(600_000) }
+        after { allow(Nandi.config).to receive(:concurrent_statement_timeout).and_call_original }
+
+        it "does not disable the statement timeout" do
+          expect(migration.disable_statement_timeout?).to be(false)
+        end
+
+        it "uses the configured concurrent statement timeout" do
+          expect(migration.statement_timeout).to eq(600_000)
+        end
+
+        it "still disables the lock timeout" do
+          expect(migration.disable_lock_timeout?).to be(true)
+        end
+      end
+
+      context "and both concurrent timeouts are configured globally" do
+        before do
+          allow(Nandi.config).to receive_messages(
+            concurrent_lock_timeout: 120_000,
+            concurrent_statement_timeout: 600_000,
+          )
+        end
+
+        it "disables neither timeout" do
+          expect(migration.disable_lock_timeout?).to be(false)
+          expect(migration.disable_statement_timeout?).to be(false)
+        end
+
+        it "uses the configured concurrent timeouts" do
+          expect(migration.lock_timeout).to eq(120_000)
+          expect(migration.statement_timeout).to eq(600_000)
+        end
+      end
+
+      context "and per-migration set_lock_timeout overrides the global concurrent config" do
+        before { allow(Nandi.config).to receive(:concurrent_lock_timeout).and_return(120_000) }
+        after { allow(Nandi.config).to receive(:concurrent_lock_timeout).and_call_original }
+
+        let(:subject_class) do
+          Class.new(described_class) do
+            set_lock_timeout(60_000)
+
+            def up
+              validate_constraint :payments, :payments_mandates_fk
+            end
+
+            def down; end
+          end
+        end
+
+        it "uses the per-migration timeout" do
+          expect(migration.lock_timeout).to eq(60_000)
+          expect(migration.disable_lock_timeout?).to be(false)
         end
       end
     end

--- a/spec/nandi/multi_database_spec.rb
+++ b/spec/nandi/multi_database_spec.rb
@@ -248,6 +248,58 @@ RSpec.describe Nandi::MultiDatabase do
       end
     end
 
+    context "with concurrent timeout defaults" do
+      let(:name) { :primary }
+
+      context "when not configured" do
+        let(:config) { {} }
+
+        it "defaults concurrent_lock_timeout to nil" do
+          expect(database.concurrent_lock_timeout).to be_nil
+        end
+
+        it "defaults concurrent_statement_timeout to nil" do
+          expect(database.concurrent_statement_timeout).to be_nil
+        end
+      end
+
+      context "when concurrent_lock_timeout is configured" do
+        let(:config) { { concurrent_lock_timeout: 120_000 } }
+
+        it "sets concurrent_lock_timeout" do
+          expect(database.concurrent_lock_timeout).to eq(120_000)
+        end
+
+        it "leaves concurrent_statement_timeout as nil" do
+          expect(database.concurrent_statement_timeout).to be_nil
+        end
+      end
+
+      context "when concurrent_statement_timeout is configured" do
+        let(:config) { { concurrent_statement_timeout: 600_000 } }
+
+        it "sets concurrent_statement_timeout" do
+          expect(database.concurrent_statement_timeout).to eq(600_000)
+        end
+
+        it "leaves concurrent_lock_timeout as nil" do
+          expect(database.concurrent_lock_timeout).to be_nil
+        end
+      end
+
+      context "when both concurrent timeouts are configured" do
+        let(:config) { { concurrent_lock_timeout: 120_000, concurrent_statement_timeout: 600_000 } }
+
+        it "sets concurrent_lock_timeout" do
+          expect(database.concurrent_lock_timeout).to eq(120_000)
+        end
+
+        it "sets concurrent_statement_timeout" do
+          expect(database.concurrent_statement_timeout).to eq(600_000)
+        end
+      end
+    end
+
     context "with explicit default flag" do
       let(:name) { :custom }
       let(:config) { { default: true } }

--- a/spec/nandi/renderers/active_record_spec.rb
+++ b/spec/nandi/renderers/active_record_spec.rb
@@ -486,9 +486,7 @@ RSpec.describe Nandi::Renderers::ActiveRecord do
                   end
                 end,
                 Class.new do
-                  def self.name
-                    "My::Other::Mixin"
-                  end
+                  define_singleton_method(:name) { "My::Other::Mixin" }
                 end,
               ]
             end


### PR DESCRIPTION
## Summary

- Adds `concurrent_lock_timeout` and `concurrent_statement_timeout` as optional global config options (per-database and top-level)
- When set, concurrent migrations (`add_index`/`remove_index`) emit `set_lock_timeout`/`set_statement_timeout` instead of `disable_lock_timeout!`/`disable_statement_timeout!`
- Defaults to `nil` — existing behaviour is fully preserved when not configured
- Per-migration `set_lock_timeout`/`set_statement_timeout` still takes precedence over the global config
- Bumps version to `2.1.0`

## Usage

```ruby
Nandi.configure do |config|
  config.register_database(:primary,
    migration_directory: "db/safe_migrations",
    output_directory: "db/migrate",
    concurrent_lock_timeout: 120_000,      # 2 minutes
    concurrent_statement_timeout: 600_000) # 10 minutes
end
```

Or via the legacy single-database setters:

```ruby
Nandi.configure do |config|
  config.concurrent_lock_timeout = 120_000      # 2 minutes
  config.concurrent_statement_timeout = 600_000 # 10 minutes
end
```

## Test plan

- [x] All 391 existing + new specs pass (`bundle exec rspec`)
- [ ] When `concurrent_lock_timeout` is set, compiled concurrent migrations use `set_lock_timeout` instead of `disable_lock_timeout!`
- [ ] When not set, behaviour is identical to previous versions
- [ ] Per-migration `set_lock_timeout` overrides the global config

🤖 Generated with [Claude Code](https://claude.com/claude-code)