### PR TITLE
Fix concurrent timeouts bleeding into ACCESS EXCLUSIVE migrations (v2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.1.1 (2026-06-06)
+
+### Bug fixes
+
+- Fix `concurrent_lock_timeout` and `concurrent_statement_timeout` incorrectly
+  applying to ACCESS EXCLUSIVE migrations. They now only affect concurrent
+  (SHARE lock) migrations as intended.
+
 ## v2.1.0 (2026-06-05)
 
 ### New features

--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -374,11 +374,19 @@ module Nandi
     end
 
     def default_statement_timeout
-      Nandi.config.concurrent_statement_timeout || Nandi.config.access_exclusive_statement_timeout
+      if strictest_lock == LockWeights::SHARE
+        Nandi.config.concurrent_statement_timeout || Nandi.config.access_exclusive_statement_timeout
+      else
+        Nandi.config.access_exclusive_statement_timeout
+      end
     end
 
     def default_lock_timeout
-      Nandi.config.concurrent_lock_timeout || Nandi.config.access_exclusive_lock_timeout
+      if strictest_lock == LockWeights::SHARE
+        Nandi.config.concurrent_lock_timeout || Nandi.config.access_exclusive_lock_timeout
+      else
+        Nandi.config.access_exclusive_lock_timeout
+      end
     end
 
     def invoke_custom_method(name, ...)

--- a/lib/nandi/version.rb
+++ b/lib/nandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nandi
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -1021,5 +1021,35 @@ RSpec.describe Nandi::Migration do
         end
       end
     end
+
+    context "when the strictest lock is ACCESS EXCLUSIVE" do
+      let(:subject_class) do
+        Class.new(described_class) do
+          def up
+            add_column :payments, :foo, :text
+          end
+
+          def down; end
+        end
+      end
+
+      context "and concurrent_lock_timeout is configured globally" do
+        before { allow(Nandi.config).to receive(:concurrent_lock_timeout).and_return(120_000) }
+        after { allow(Nandi.config).to receive(:concurrent_lock_timeout).and_call_original }
+
+        it "does not use the concurrent lock timeout" do
+          expect(migration.lock_timeout).to eq(Nandi.config.access_exclusive_lock_timeout)
+        end
+      end
+
+      context "and concurrent_statement_timeout is configured globally" do
+        before { allow(Nandi.config).to receive(:concurrent_statement_timeout).and_return(600_000) }
+        after { allow(Nandi.config).to receive(:concurrent_statement_timeout).and_call_original }
+
+        it "does not use the concurrent statement timeout" do
+          expect(migration.statement_timeout).to eq(Nandi.config.access_exclusive_statement_timeout)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Bug

In v2.1.0 we simplified `default_lock_timeout` and `default_statement_timeout` by removing the `strictest_lock == LockWeights::SHARE` guard. This caused `concurrent_lock_timeout` and `concurrent_statement_timeout` to be applied to **all** migrations, including ACCESS EXCLUSIVE ones.

**Before the regression (correct):**
```ruby
set_lock_timeout(5000)     # access_exclusive_lock_timeout
set_statement_timeout(1500)
```

**After the regression (wrong):**
```ruby
set_lock_timeout(120000)   # concurrent_lock_timeout incorrectly applied
set_statement_timeout(600000)
```

## Fix

Restore the `strictest_lock == LockWeights::SHARE` guard in both `default_lock_timeout` and `default_statement_timeout` so concurrent timeout defaults only apply to SHARE lock (concurrent index) operations. Also restores the ACCESS EXCLUSIVE test cases that were removed during the simplification.

## Changelog

### v2.1.1 (2026-06-06)

**Bug fixes**
- Fix `concurrent_lock_timeout` and `concurrent_statement_timeout` incorrectly applying to ACCESS EXCLUSIVE migrations. They now only affect concurrent (SHARE lock) migrations as intended.

## Test plan

- [x] CI passes
- [ ] ACCESS EXCLUSIVE migrations use `access_exclusive_lock_timeout` / `access_exclusive_statement_timeout`
- [ ] Concurrent migrations use `concurrent_lock_timeout` / `concurrent_statement_timeout` when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)