### PR TITLE
Add migration modifier framework with CreateTableValidatesFks

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,16 @@ Register a block to be called on output, for example a code formatter. Whatever 
 config.post_process { |migration| MyFormatter.format(migration) }
 ```
 
+#register_migration_modifier(klass)
+
+Register a custom migration modifier. Migration modifiers inherit from `Nandi::MigrationModifiers::Base` and implement `.up(instructions)`, `.down(instructions)`, or both. Nandi calls the appropriate method based on migration direction.
+
+Nandi ships with one built-in modifier, `Nandi::MigrationModifiers::CreateTableValidatesFks`, which is enabled by default. See the [Migration Modifiers](#migration-modifiers) section for details.
+
+```rb
+config.register_migration_modifier(MyCustomModifier)
+```
+
 #register_method(name, klass)
 
 Register a custom DDL method.
@@ -482,6 +492,56 @@ Parameters:
 `name` (Symbol) - The name of the method to create. This will be monkey-patched into Nandi::Migration.
 
 `klass` (Class) — The class to initialise with the arguments to the method. It should define a `template` instance method which will return a subclass of Cell::ViewModel from the Cells templating library and a `procedure` method that returns the name of the method. It may optionally define a `mixins` method, which will return an array of `Module`s to be mixed into any migration that uses this method.
+
+## Migration Modifiers
+
+Migration modifiers allow instructions to change their behaviour based on other instructions in the same migration. After the direction block runs, Nandi iterates over all configured modifiers and passes the full instruction list to each one.
+
+### Built-in: `CreateTableValidatesFks`
+
+When you create a table and add a foreign key on that same table in a single migration, the FK does not need the usual `NOT VALID` deferral — the table is brand new, so there are no existing rows to validate. Nandi detects this automatically and sets `validate: true` on the relevant FK instructions:
+
+```rb
+class CreatePaymentsWithFk < Nandi::Migration
+  def up
+    create_table :payments do |t|
+      t.bigint :mandate_id, null: false
+    end
+
+    add_foreign_key :payments, :mandates
+  end
+end
+```
+
+The compiled output will include `validate: true` on the `add_foreign_key` call, skipping the separate validate step that would otherwise be required.
+
+This modifier is enabled by default. To disable it, you would need to replace `config.migration_modifiers` entirely — there is no built-in opt-out.
+
+### Writing a custom modifier
+
+Inherit from `Nandi::MigrationModifiers::Base` and override `.up`, `.down`, or both. The base class provides no-op defaults so you only implement what you need:
+
+```rb
+class MyModifier < Nandi::MigrationModifiers::Base
+  def self.up(instructions)
+    # inspect and mutate instructions for the up direction
+  end
+
+  def self.down(instructions)
+    # inspect and mutate instructions for the down direction
+  end
+end
+```
+
+Register it in your Nandi initializer:
+
+```rb
+Nandi.configure do |config|
+  config.register_migration_modifier(MyModifier)
+end
+```
+
+Modifiers are applied in registration order, after all built-in modifiers.
 
 ## Multi-Database Support
 

--- a/lib/nandi/config.rb
+++ b/lib/nandi/config.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "nandi/migration_modifiers"
 require "nandi/renderers"
 require "nandi/lockfile"
 require "nandi/multi_database"
@@ -30,13 +31,18 @@ module Nandi
     attr_writer :lockfile_directory
 
     # @api private
-    attr_reader :post_processor, :custom_methods
+    attr_reader :post_processor, :custom_methods, :migration_modifiers
 
     def initialize(renderer: Renderers::ActiveRecord)
       @renderer = renderer
       @custom_methods = {}
       @compile_files = DEFAULT_COMPILE_FILES
       @lockfile_directory = DEFAULT_LOCKFILE_DIRECTORY
+      @migration_modifiers = [MigrationModifiers::CreateTableValidatesFks]
+    end
+
+    def register_migration_modifier(klass)
+      @migration_modifiers << klass
     end
 
     # Register a block to be called on output, for example a code formatter. Whatever is

--- a/lib/nandi/instructions/add_foreign_key.rb
+++ b/lib/nandi/instructions/add_foreign_key.rb
@@ -5,24 +5,29 @@ require "active_support/inflector"
 module Nandi
   module Instructions
     class AddForeignKey
-      attr_reader :table, :target
+      attr_reader :table, :target, :validate
 
       def initialize(table:, target:, name: nil, **extra_args)
         @table = table
         @target = target
         @extra_args = extra_args
         @name = name
+        @validate = false
       end
 
       def procedure
         :add_foreign_key
       end
 
+      def validate!
+        @validate = true
+      end
+
       def extra_args
         {
           **@extra_args,
           name: name,
-          validate: false,
+          validate: validate,
         }.compact
       end
 

--- a/lib/nandi/migration.rb
+++ b/lib/nandi/migration.rb
@@ -317,6 +317,8 @@ module Nandi
 
       public_send(direction) unless current_instructions.any?
 
+      Nandi.config.migration_modifiers.each { |mod| mod.public_send(direction, current_instructions) }
+
       current_instructions
     end
 

--- a/lib/nandi/migration_modifiers.rb
+++ b/lib/nandi/migration_modifiers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "nandi/migration_modifiers/base"
+require "nandi/migration_modifiers/create_table_validates_fks"
+
+module Nandi
+  module MigrationModifiers
+  end
+end

--- a/lib/nandi/migration_modifiers/base.rb
+++ b/lib/nandi/migration_modifiers/base.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Nandi
+  module MigrationModifiers
+    class Base
+      def self.up(instructions); end
+      def self.down(instructions); end
+    end
+  end
+end

--- a/lib/nandi/migration_modifiers/create_table_validates_fks.rb
+++ b/lib/nandi/migration_modifiers/create_table_validates_fks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Nandi
+  module MigrationModifiers
+    class CreateTableValidatesFks < Base
+      def self.up(instructions)
+        new_tables = instructions.
+          select { |i| i.procedure == :create_table }.
+          to_set { |i| i.table.to_sym }
+
+        return if new_tables.empty?
+
+        instructions.
+          grep(Instructions::AddForeignKey).
+          select { |i| new_tables.include?(i.table.to_sym) }.
+          each(&:validate!)
+      end
+    end
+  end
+end

--- a/spec/nandi/config_spec.rb
+++ b/spec/nandi/config_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "nandi/config"
+require "nandi/migration_modifiers"
 
 RSpec.describe Nandi::Config do
   subject(:config) { described_class.new }
@@ -126,6 +127,30 @@ RSpec.describe Nandi::Config do
 
       # Should raise error from MultiDatabase validation
       expect { config.validate! }.to raise_error(ArgumentError, /Missing default database/)
+    end
+  end
+
+  describe "#migration_modifiers" do
+    it "defaults to [CreateTableValidatesFks]" do
+      expect(config.migration_modifiers).to eq(
+        [Nandi::MigrationModifiers::CreateTableValidatesFks],
+      )
+    end
+  end
+
+  describe "#register_migration_modifier" do
+    it "appends the modifier to the list" do
+      modifier = Class.new
+      config.register_migration_modifier(modifier)
+      expect(config.migration_modifiers).to include(modifier)
+    end
+
+    it "preserves existing modifiers" do
+      modifier = Class.new
+      config.register_migration_modifier(modifier)
+      expect(config.migration_modifiers).to include(
+        Nandi::MigrationModifiers::CreateTableValidatesFks,
+      )
     end
   end
 

--- a/spec/nandi/instructions/add_foreign_key_spec.rb
+++ b/spec/nandi/instructions/add_foreign_key_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nandi/instructions/add_foreign_key"
+
+RSpec.describe Nandi::Instructions::AddForeignKey do
+  subject(:instruction) { described_class.new(table: :payments, target: :mandates) }
+
+  describe "#extra_args" do
+    it "defaults validate to false" do
+      expect(instruction.extra_args).to include(validate: false)
+    end
+  end
+
+  describe "#validate!" do
+    before { instruction.validate! }
+
+    it "sets validate to true in extra_args" do
+      expect(instruction.extra_args).to include(validate: true)
+    end
+  end
+end

--- a/spec/nandi/migration_modifiers/create_table_validates_fks_spec.rb
+++ b/spec/nandi/migration_modifiers/create_table_validates_fks_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nandi/instructions/add_foreign_key"
+require "nandi/instructions/create_table"
+require "nandi/migration_modifiers/create_table_validates_fks"
+
+RSpec.describe Nandi::MigrationModifiers::CreateTableValidatesFks do
+  def fk(table:, target: :mandates)
+    Nandi::Instructions::AddForeignKey.new(table: table, target: target)
+  end
+
+  def create_table(table)
+    Nandi::Instructions::CreateTable.new(table: table, columns_block: proc {})
+  end
+
+  describe ".up" do
+    context "when the FK table is created in the same instruction set" do
+      it "sets validate to true on the FK" do
+        fk_instruction = fk(table: :payments)
+        described_class.up([create_table(:payments), fk_instruction])
+        expect(fk_instruction.extra_args).to include(validate: true)
+      end
+
+      it "is order-independent when FK comes before create_table" do
+        fk_instruction = fk(table: :payments)
+        described_class.up([fk_instruction, create_table(:payments)])
+        expect(fk_instruction.extra_args).to include(validate: true)
+      end
+    end
+
+    context "when a different table is created" do
+      it "leaves validate as false" do
+        fk_instruction = fk(table: :payments)
+        described_class.up([create_table(:widgets), fk_instruction])
+        expect(fk_instruction.extra_args).to include(validate: false)
+      end
+    end
+
+    context "when no table is created" do
+      it "leaves validate as false" do
+        fk_instruction = fk(table: :payments)
+        described_class.up([fk_instruction])
+        expect(fk_instruction.extra_args).to include(validate: false)
+      end
+    end
+
+    context "with multiple FKs on the new table" do
+      it "sets validate to true on all of them" do
+        fk1 = fk(table: :payments, target: :mandates)
+        fk2 = fk(table: :payments, target: :customers)
+        described_class.up([create_table(:payments), fk1, fk2])
+        expect(fk1.extra_args).to include(validate: true)
+        expect(fk2.extra_args).to include(validate: true)
+      end
+    end
+  end
+
+  describe ".down" do
+    it "is a no-op" do
+      fk_instruction = fk(table: :payments)
+      described_class.down([create_table(:payments), fk_instruction])
+      expect(fk_instruction.extra_args).to include(validate: false)
+    end
+  end
+end

--- a/spec/nandi/migration_spec.rb
+++ b/spec/nandi/migration_spec.rb
@@ -665,6 +665,63 @@ RSpec.describe Nandi::Migration do
         )
       end
     end
+
+    context "when the same migration creates the FK table" do
+      subject(:fk_instruction) do
+        subject_class.new(validator).up_instructions.find { |i| i.procedure == :add_foreign_key }
+      end
+
+      context "with create_table before add_foreign_key" do
+        let(:subject_class) do
+          Class.new(described_class) do
+            def up
+              create_table(:payments) { |t| t.text :foo }
+              add_foreign_key :payments, :mandates
+            end
+
+            def down; end
+          end
+        end
+
+        it "sets validate to true" do
+          expect(fk_instruction.extra_args).to include(validate: true)
+        end
+      end
+
+      context "with add_foreign_key before create_table" do
+        let(:subject_class) do
+          Class.new(described_class) do
+            def up
+              add_foreign_key :payments, :mandates
+              create_table(:payments) { |t| t.text :foo }
+            end
+
+            def down; end
+          end
+        end
+
+        it "sets validate to true" do
+          expect(fk_instruction.extra_args).to include(validate: true)
+        end
+      end
+
+      context "when a different table is created" do
+        let(:subject_class) do
+          Class.new(described_class) do
+            def up
+              create_table(:widgets) { |t| t.text :foo }
+              add_foreign_key :payments, :mandates
+            end
+
+            def down; end
+          end
+        end
+
+        it "leaves validate as false" do
+          expect(fk_instruction.extra_args).to include(validate: false)
+        end
+      end
+    end
   end
 
   describe "#add_check_constraint" do


### PR DESCRIPTION
We've run into a situation where engineers are creating new tables with foreign keys but because of the defaults on `add_foreign_key`, are not following up with a `validate` migration, leading to some tables having a `NOT VALID` fk.

This PR introduces a migration modifier class that has context on the migrations being run and if there is a `create_table` in the chain with an `add_foreign_key`, will validate the fk on add.