### PR TITLE
Move instruction->validator mapping to instruction class

### DIFF
--- a/lib/nandi/instructions/add_column.rb
+++ b/lib/nandi/instructions/add_column.rb
@@ -19,6 +19,10 @@ module Nandi
       def lock
         Nandi::Migration::LockWeights::ACCESS_EXCLUSIVE
       end
+
+      def validator
+        Validation::AddColumnValidator
+      end
     end
   end
 end

--- a/lib/nandi/instructions/add_index.rb
+++ b/lib/nandi/instructions/add_index.rb
@@ -32,6 +32,10 @@ module Nandi
         Nandi::Migration::LockWeights::SHARE
       end
 
+      def validator
+        Validation::AddIndexValidator
+      end
+
       attr_reader :table, :fields
 
       private

--- a/lib/nandi/instructions/add_reference.rb
+++ b/lib/nandi/instructions/add_reference.rb
@@ -19,6 +19,10 @@ module Nandi
       def lock
         Nandi::Migration::LockWeights::ACCESS_EXCLUSIVE
       end
+
+      def validator
+        Validation::AddReferenceValidator
+      end
     end
   end
 end

--- a/lib/nandi/instructions/remove_index.rb
+++ b/lib/nandi/instructions/remove_index.rb
@@ -24,6 +24,10 @@ module Nandi
         Nandi::Migration::LockWeights::SHARE
       end
 
+      def validator
+        Validation::RemoveIndexValidator
+      end
+
       attr_reader :table
 
       private

--- a/lib/nandi/validation/each_validator.rb
+++ b/lib/nandi/validation/each_validator.rb
@@ -16,18 +16,9 @@ module Nandi
       end
 
       def call
-        case instruction.procedure
-        when :add_index
-          AddIndexValidator.call(instruction)
-        when :remove_index
-          RemoveIndexValidator.call(instruction)
-        when :add_column
-          AddColumnValidator.call(instruction)
-        when :add_reference
-          AddReferenceValidator.call(instruction)
-        else
-          success
-        end
+        return success unless instruction.respond_to?(:validator)
+
+        instruction.validator.call(instruction)
       end
 
       attr_reader :instruction

--- a/lib/nandi/validation/failure_helpers.rb
+++ b/lib/nandi/validation/failure_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "dry/monads/result"
+require "dry/monads"
 
 module Nandi
   module Validation

--- a/spec/nandi/validation/each_validator_spec.rb
+++ b/spec/nandi/validation/each_validator_spec.rb
@@ -11,11 +11,7 @@ RSpec.describe Nandi::Validation::EachValidator do
 
   describe "#call" do
     context "when the given instruction is to remove an index" do
-      let(:instruction) { instance_double(Nandi::Instructions::RemoveIndex) }
-
-      before do
-        allow(instruction).to receive(:procedure).and_return(:remove_index)
-      end
+      let(:instruction) { Nandi::Instructions::RemoveIndex.new(table: :payments, field: :foo) }
 
       it "calls RemoveIndexValidator" do
         expect(Nandi::Validation::RemoveIndexValidator).to receive(:call).
@@ -26,11 +22,7 @@ RSpec.describe Nandi::Validation::EachValidator do
     end
 
     context "when the given instruction is to add a column" do
-      let(:instruction) { instance_double(Nandi::Instructions::AddColumn) }
-
-      before do
-        allow(instruction).to receive(:procedure).and_return(:add_column)
-      end
+      let(:instruction) { Nandi::Instructions::AddColumn.new(table: :payments, name: :foo, type: :text) }
 
       it "calls AddColumnValidator" do
         expect(Nandi::Validation::AddColumnValidator).to receive(:call).with(instruction)
@@ -40,11 +32,7 @@ RSpec.describe Nandi::Validation::EachValidator do
     end
 
     context "when the given instruction is to add a reference" do
-      let(:instruction) { instance_double(Nandi::Instructions::AddReference) }
-
-      before do
-        allow(instruction).to receive(:procedure).and_return(:add_reference)
-      end
+      let(:instruction) { Nandi::Instructions::AddReference.new(table: :payments, ref_name: :user) }
 
       it "calls AddReferenceValidator" do
         expect(Nandi::Validation::AddReferenceValidator).to receive(:call).
@@ -55,11 +43,7 @@ RSpec.describe Nandi::Validation::EachValidator do
     end
 
     context "when the given instruction is to add an index" do
-      let(:instruction) { instance_double(Nandi::Instructions::AddIndex) }
-
-      before do
-        allow(instruction).to receive(:procedure).and_return(:add_index)
-      end
+      let(:instruction) { Nandi::Instructions::AddIndex.new(table: :payments, fields: [:foo]) }
 
       it "calls AddIndexValidator" do
         expect(Nandi::Validation::AddIndexValidator).to receive(:call).
@@ -70,11 +54,7 @@ RSpec.describe Nandi::Validation::EachValidator do
     end
 
     context "when the given instruction isn't explicitly validated" do
-      let(:instruction) { instance_double(Nandi::Instructions::AddForeignKey) }
-
-      before do
-        allow(instruction).to receive(:procedure).and_return(:add_foreign_key)
-      end
+      let(:instruction) { Nandi::Instructions::AddForeignKey.new(table: :payments, target: :users) }
 
       it "returns successful" do
         expect(call).to eq(Dry::Monads::Result::Success.new(nil))


### PR DESCRIPTION
This moves the mapping of Instructions to their Validators into the instruction class itself.

This makes it cleaner to configure new instructions with fewer seams, and allow gems to extend the validation suite without monkey-patching over the switch statement.